### PR TITLE
Expand ARM64 rbCode (and scratch) to 128 and document why.

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -313,7 +313,7 @@ class CDetourDis
 
     LONG                m_lScratchExtra;
     PBYTE               m_pbScratchTarget;
-    BYTE                m_rbScratchDst[64];
+    BYTE                m_rbScratchDst[64]; // matches or exceeds rbCode
 };
 
 PVOID WINAPI DetourCopyInstruction(_In_opt_ PVOID pDst,
@@ -2547,7 +2547,7 @@ class CDetourDis
     PBYTE   m_pbPool;
     LONG    m_lExtra;
 
-    BYTE    m_rbScratchDst[64];
+    BYTE    m_rbScratchDst[64]; // matches or exceeds rbCode
 
     static const COPYENTRY s_rceCopyTable[33];
 };
@@ -3866,7 +3866,7 @@ class CDetourDis
 
   protected:
     PBYTE   m_pbTarget;
-    BYTE    m_rbScratchDst[64];
+    BYTE    m_rbScratchDst[128]; // matches or exceeds rbCode
 };
 
 BYTE CDetourDis::PureCopy32(BYTE* pSource, BYTE* pDest)


### PR DESCRIPTION
This is a little high, but 64 seemed low.

Change 114686 by NTDEV\jaykrell@JAYKRELL100-4 on 2017/10/23 19:06:28
        Expand ARM64 rbCode (and scratch) to 128 and document why.
        This is a little high, but 64 seemed low.
Affected files ...
... //depot/969/private/jaykrell/3.0/src/detours.cpp#27 edit
... //depot/969/private/jaykrell/3.0/src/disasm.cpp#68 edit