### PR TITLE
Correct ARM64 SIZE_OF_JMP from 8 to 16 and spell out 2*4 as 8.

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -893,7 +893,7 @@ struct _DETOUR_TRAMPOLINE
 C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 120);
 
 enum {
-    SIZE_OF_JMP = 8
+    SIZE_OF_JMP = 16
 };
 
 inline ULONG fetch_opcode(PBYTE pbCode)
@@ -915,7 +915,7 @@ PBYTE detour_gen_jmp_immediate(PBYTE pbCode, PBYTE *ppPool, PBYTE pbJmpVal)
         pbLiteral = *ppPool;
     }
     else {
-        pbLiteral = pbCode + 2*4;
+        pbLiteral = pbCode + 8;
     }
 
     *((PBYTE*&)pbLiteral) = pbJmpVal;


### PR DESCRIPTION
This is a lot of bytes to overwrite, and it precludes
patching a number of small-ish functions, but it is how many.

For example, automatic following imports, has lead to system service stubs,
that were smaller than this (and aligned less than this).

Part of this change:

Change 112950 by REDMOND\galenh@galenh2 on 2016/11/07 16:24:57
           Build_340: Fix compilation error on ARM64.  Fix jmp region calculations on ARM & ARM64.
Affected files ...
... //depot/969/3.0/README.TXT#58 edit
... //depot/969/3.0/src/creatwth.cpp#61 edit
... //depot/969/3.0/src/detours.cpp#69 edit
... //depot/969/3.0/src/detours.h#68 edit
... //depot/969/3.0/src/detver.h#46 edit
... //depot/969/3.0/src/disasm.cpp#56 edit
... //depot/969/3.0/src/image.cpp#51 edit
... //depot/969/3.0/src/Makefile#57 edit
... //depot/969/3.0/src/modules.cpp#56 edit
... //depot/969/3.0/src/uimports.cpp#48 edit