### PR TITLE
Remove dead code and add a comment.

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1714,17 +1714,12 @@ BOOL CImage::Write(HANDLE hFile)
         m_nNextFileAddr = Max(m_SectionHeaders[n].PointerToRawData +
                               m_SectionHeaders[n].SizeOfRawData,
                               m_nNextFileAddr);
-#if 0
-        m_nNextVirtAddr = Max(m_SectionHeaders[n].VirtualAddress +
-                              m_SectionHeaders[n].Misc.VirtualSize,
-                              m_nNextVirtAddr);
-#else
+        // Old images have VirtualSize == 0 as a matter of course, e.g. NT 3.1.
         m_nNextVirtAddr = Max(m_SectionHeaders[n].VirtualAddress +
                               (m_SectionHeaders[n].Misc.VirtualSize
                                ? m_SectionHeaders[n].Misc.VirtualSize
                                : SectionAlign(m_SectionHeaders[n].SizeOfRawData)),
                               m_nNextVirtAddr);
-#endif
 
         m_nExtraOffset = Max(m_nNextFileAddr, m_nExtraOffset);
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1715,6 +1715,7 @@ BOOL CImage::Write(HANDLE hFile)
                               m_SectionHeaders[n].SizeOfRawData,
                               m_nNextFileAddr);
         // Old images have VirtualSize == 0 as a matter of course, e.g. NT 3.1.
+        // In which case, use SizeOfRawData instead.
         m_nNextVirtAddr = Max(m_SectionHeaders[n].VirtualAddress +
                               (m_SectionHeaders[n].Misc.VirtualSize
                                ? m_SectionHeaders[n].Misc.VirtualSize


### PR DESCRIPTION
i.e. repair from porting:

Change 112862 by NTDEV\jaykrell@JAYKRELL100-4 on 2016/10/19 17:10:49
        Support VirtualSize == 0, i.e. NT 3.1 images.
Affected files ...
... //depot/969/private/jaykrell/3.0/src/image.cpp#15 edit