### PR TITLE
Fix 4GB offset checks in UPDATE_IMPORTS_XX/FindAndAllocateNearBase

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -180,16 +180,6 @@ static PBYTE FindAndAllocateNearBase(HANDLE hProcess, PBYTE pbBase, DWORD cbAllo
 
         PBYTE pbAddress = (PBYTE)(((DWORD_PTR)mbi.BaseAddress + 0xffff) & ~(DWORD_PTR)0xffff);
 
-#ifdef _WIN64
-        // The distance from pbBase to pbAddress must fit in 32 bits.
-        //
-        const size_t GB4 = ((((size_t)1) << 32) - 1);
-        if ((size_t)(pbAddress - pbBase) > GB4) {
-            DETOUR_TRACE(("FindAndAllocateNearBase(1) failing due to distance >4GB %p\n", pbAddress));
-            return NULL;
-        }
-#endif
-
         DETOUR_TRACE(("Free region %p..%p\n",
                       mbi.BaseAddress,
                       (PBYTE)mbi.BaseAddress + mbi.RegionSize));
@@ -201,14 +191,7 @@ static PBYTE FindAndAllocateNearBase(HANDLE hProcess, PBYTE pbBase, DWORD cbAllo
                 DETOUR_TRACE(("VirtualAllocEx(%p) failed: %d\n", pbAddress, GetLastError()));
                 continue;
             }
-#ifdef _WIN64
-            // The distance from pbBase to pbAddress must fit in 32 bits.
-            //
-            if ((size_t)(pbAddress - pbBase) > GB4) {
-                DETOUR_TRACE(("FindAndAllocateNearBase(2) failing due to distance >4GB %p\n", pbAddress));
-                return NULL;
-            }
-#endif
+
             DETOUR_TRACE(("[%p..%p] Allocated for import table.\n",
                           pbAlloc, pbAlloc + cbAlloc));
             return pbAlloc;


### PR DESCRIPTION
On x64, imports are found via a 32-bit offset from the start of the image. As a result, when Detours replaces imports on x64, it must make sure that the offsets to the new imports fit into a 32-bit variable.

Before this change, FindAndAllocateNearBase tried to validate this requirement, but its logic wasn't quite right. It used its pbBase argument, which is strictly larger than the start of the image, to validate that the offset from pbBase to the its new allocation fitted into 32-bits. This could fail if:
   1) pbBase wasn't page-aligned AND
   2) pbBase fell in a pure free region

This is because FindAndAllocateNearBase could decide to allocate at the page boundary below pbBase, since VirtualQueryEx rounds its inputted address down to its next page boundary. This meant that pbAddress - pbBase could be a very large number, which would fail the old 4GB checks in FindAndAllocateNearBase.

The fix for this issue is to move the 4GB checks up into FindAndAllocateNearBase's caller, i.e. UPDATE_IMPORTS_XX. This allows us to check the exact values that must fit into 32-bits, instead of incorrectly checking offsets from pbBase.

This change ultimately allows us to inject our DLLs into some video games with unusual size values in their _IMAGE_OPTIONAL_HEADER structs. pbBase is calculated using these sizes, so these unusual sizes resulted in pbBase's value satisfying both of the conditions mentioned above. This resulted in us failing the old 4GB checks in FindAndAllocateNearBase, which meant that we failed to inject our DLLs into the process.