### PR TITLE
Establish ARM64 baseline.

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -39,8 +39,10 @@ all:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
     cd "$(MAKEDIR)\echo"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\einst"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X86"
     cd "$(MAKEDIR)\excep"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
@@ -49,9 +51,11 @@ all:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
     cd "$(MAKEDIR)\commem"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\findfunc"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
-!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM"
+!ENDIF
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM" && "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\member"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
 !ENDIF
@@ -77,7 +81,7 @@ all:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
     cd "$(MAKEDIR)\tracelnk"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
-!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM"
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM" && "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\tryman"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
 !ENDIF
@@ -218,34 +222,42 @@ test:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\simple"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\slept"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\setdll"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\withdll"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X86"
     cd "$(MAKEDIR)\cping"
 #   @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 !ENDIF
     cd "$(MAKEDIR)\disas"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\dtest"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
     cd "$(MAKEDIR)\dumpe"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\dumpi"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\echo"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\einst"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X86"
     cd "$(MAKEDIR)\excep"
 #   @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 !ENDIF
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\comeasy"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+
     cd "$(MAKEDIR)\commem"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\findfunc"
@@ -254,10 +266,12 @@ test:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\region"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X64" || "$(DETOURS_TARGET_PROCESSOR)" == "IA64"
     cd "$(MAKEDIR)\talloc"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 !ENDIF
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\traceapi"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\tracebld"
@@ -268,12 +282,15 @@ test:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)\traceser"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
 #    cd "$(MAKEDIR)\tracessl"
 #    @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 #    cd "$(MAKEDIR)\tracetcp"
 #    @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!IF "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
     cd "$(MAKEDIR)\tracelnk"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+!ENDIF
     cd "$(MAKEDIR)\impmunge"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)"

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -974,6 +974,19 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
     return pbCode;
 }
 
+inline void detour_find_jmp_bounds(PBYTE pbCode,
+                                   PDETOUR_TRAMPOLINE *ppLower,
+                                   PDETOUR_TRAMPOLINE *ppUpper)
+{
+    // We have to place trampolines within +/- 2GB of code.
+    ULONG_PTR lo = detour_2gb_below((ULONG_PTR)pbCode);
+    ULONG_PTR hi = detour_2gb_above((ULONG_PTR)pbCode);
+    DETOUR_TRACE(("[%p..%p..%p]\n", lo, pbCode, hi));
+
+    *ppLower = (PDETOUR_TRAMPOLINE)lo;
+    *ppUpper = (PDETOUR_TRAMPOLINE)hi;
+}
+
 inline BOOL detour_does_code_end_function(PBYTE pbCode)
 {
     ULONG Opcode = fetch_opcode(pbCode);


### PR DESCRIPTION
This establishes a baseline for ARM64 of compiling/non-compiling tests and working/non-working tests for ARM64.  There are a number of pull requests with bug fixes and this will let us validate them.  Presumably we'll be able to move more tests to working status after the bug fixes.

This also add a missing function detour_jmp_find_bounds for ARM64.  Jay, I just copied the 32-bit ARM one.  If there's a better fix, let me know.
