### PR TITLE
Use DetourCreateProcessWithDllExA/W to allow cross-bitness detouring (traceapi sample)

### DIFF
--- a/samples/traceapi/_win32.cpp
+++ b/samples/traceapi/_win32.cpp
@@ -12741,18 +12741,18 @@ BOOL __stdcall Mine_CreateProcessA(LPCSTR lpApplicationName,
 
     BOOL rv = 0;
     __try {
-        rv = DetourCreateProcessWithDllA(lpApplicationName,
-                                         lpCommandLine,
-                                         lpProcessAttributes,
-                                         lpThreadAttributes,
-                                         bInheritHandles,
-                                         dwCreationFlags,
-                                         lpEnvironment,
-                                         lpCurrentDirectory,
-                                         lpStartupInfo,
-                                         lpProcessInformation,
-                                         s_szDllPath,
-                                         Real_CreateProcessA);
+        rv = DetourCreateProcessWithDllExA(lpApplicationName,
+                                           lpCommandLine,
+                                           lpProcessAttributes,
+                                           lpThreadAttributes,
+                                           bInheritHandles,
+                                           dwCreationFlags,
+                                           lpEnvironment,
+                                           lpCurrentDirectory,
+                                           lpStartupInfo,
+                                           lpProcessInformation,
+                                           s_szDllPath,
+                                           Real_CreateProcessA);
     } __finally {
         _PrintExit("CreateProcessA(,,,,,,,,,) -> %x (proc:%d/%p, thrd:%d/%p\n", rv,
                    lpProcessInformation->dwProcessId,
@@ -12794,18 +12794,18 @@ BOOL __stdcall Mine_CreateProcessW(LPCWSTR lpApplicationName,
 
     BOOL rv = 0;
     __try {
-        rv = DetourCreateProcessWithDllW(lpApplicationName,
-                                         lpCommandLine,
-                                         lpProcessAttributes,
-                                         lpThreadAttributes,
-                                         bInheritHandles,
-                                         dwCreationFlags,
-                                         lpEnvironment,
-                                         lpCurrentDirectory,
-                                         lpStartupInfo,
-                                         lpProcessInformation,
-                                         s_szDllPath,
-                                         Real_CreateProcessW);
+        rv = DetourCreateProcessWithDllExW(lpApplicationName,
+                                           lpCommandLine,
+                                           lpProcessAttributes,
+                                           lpThreadAttributes,
+                                           bInheritHandles,
+                                           dwCreationFlags,
+                                           lpEnvironment,
+                                           lpCurrentDirectory,
+                                           lpStartupInfo,
+                                           lpProcessInformation,
+                                           s_szDllPath,
+                                           Real_CreateProcessW);
     } __finally {
         _PrintExit("CreateProcessW(,,,,,,,,,) -> %x (proc:%d/%p, thrd:%d/%p\n", rv,
                    lpProcessInformation->dwProcessId,


### PR DESCRIPTION
This commit fixes #18:

> The traceapi sample cannot detour a 32-bit child process from a 64-bit process (and vice versa) since it calls `DetourCreateProcessWithDllA/W` instead of the 'Ex' versions in `Mine_CreateProcessA/W`

After this fix:

```
C:\home\refs\Detours\bin.X64>withdll.exe /d:trcapi64.dll cmd
withdll.exe: Starting: `cmd'
withdll.exe:   with `C:\home\refs\Detours\bin.X64\trcapi64.dll'
Microsoft Windows [Version 10.0.17134.376]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\home\refs\Detours\bin.X64>c:\windows\SysWOW64\cmd
Microsoft Windows [Version 10.0.17134.376]
(c) 2018 Microsoft Corporation. All rights reserved.

C:\home\refs\Detours\bin.X64>
```