### PR TITLE
Add a new sample dynamic_alloc to test the new API

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -87,6 +87,8 @@ all:
 !ENDIF
     cd "$(MAKEDIR)\impmunge"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS)
+    cd "$(MAKEDIR)\dynamic_alloc"
+    @$(MAKE) /NOLOGO /$(MAKEFLAGS)
     cd "$(MAKEDIR)"
 
 clean:
@@ -147,6 +149,8 @@ clean:
     cd "$(MAKEDIR)\tryman"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) clean
     cd "$(MAKEDIR)\impmunge"
+    @$(MAKE) /NOLOGO /$(MAKEFLAGS) clean
+    cd "$(MAKEDIR)\dynamic_alloc"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) clean
     cd "$(MAKEDIR)"
     -rmdir lib32 2>nul
@@ -211,6 +215,8 @@ realclean:
     cd "$(MAKEDIR)\tryman"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) realclean
     cd "$(MAKEDIR)\impmunge"
+    @$(MAKE) /NOLOGO /$(MAKEFLAGS) realclean
+    cd "$(MAKEDIR)\dynamic_alloc"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) realclean
     cd "$(MAKEDIR)"
     -rmdir lib32 2>nul
@@ -292,6 +298,8 @@ test:
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
 !ENDIF
     cd "$(MAKEDIR)\impmunge"
+    @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
+    cd "$(MAKEDIR)\dynamic_alloc"
     @$(MAKE) /NOLOGO /$(MAKEFLAGS) test
     cd "$(MAKEDIR)"
 

--- a/samples/dynamic_alloc/Makefile
+++ b/samples/dynamic_alloc/Makefile
@@ -1,0 +1,77 @@
+##############################################################################
+##
+##  Makefile for Detours Test Programs.
+##
+##  Microsoft Research Detours Package
+##
+##  Copyright (c) Microsoft Corporation.  All rights reserved.
+##
+
+!include ..\common.mak
+
+# This test is x86 only
+!IF "$(DETOURS_TARGET_PROCESSOR)" == "X86" || "$(DETOURS_TARGET_PROCESSOR)" == "X64"
+
+TARGET_NAME=dalloc
+CFLAGS=\
+	$(CFLAGS)\
+	/EHsc\
+
+LIBS=$(LIBS)\
+	user32.lib\
+
+all: dirs $(BIND)\$(TARGET_NAME).exe
+
+##############################################################################
+
+clean:
+	-del $(BIND)\$(TARGET_NAME).* 2>nul
+	-rmdir /q /s $(OBJD) 2>nul
+
+realclean: clean
+	-rmdir /q /s $(OBJDS) 2>nul
+
+##############################################################################
+
+dirs:
+	@if not exist $(BIND) mkdir $(BIND) && echo.   Created $(BIND)
+	@if not exist $(OBJD) mkdir $(OBJD) && echo.   Created $(OBJD)
+
+!IF "$(DETOURS_TARGET_PROCESSOR)" == "X64"
+$(OBJD)\asm.obj : x64.asm
+	$(ASM) $(AFLAGS) /Fl$(OBJD)\x64.lst /Fo$(OBJD)\asm.obj x64.asm
+!ELSE
+$(OBJD)\asm.obj : x86.asm
+	$(ASM) $(AFLAGS) /Fl$(OBJD)\x86.lst /Fo$(OBJD)\asm.obj x86.asm
+!ENDIF
+
+$(OBJD)\main.obj : main.cpp
+
+$(BIND)\$(TARGET_NAME).exe : $(OBJD)\main.obj $(OBJD)\asm.obj $(DEPS)
+	link\
+		/SUBSYSTEM:CONSOLE\
+		$(LINKFLAGS)\
+		$(LIBS)\
+		/PDB:"$(@R).pdb"\
+		/OUT:"$@"\
+		$**\
+
+##############################################################################
+
+test: all
+	$(BIND)\$(TARGET_NAME).exe
+
+##############################################################################
+
+!ELSE
+
+all:
+  @echo The platform `$(DETOURS_TARGET_PROCESSOR)` is not supported.  Skipping.
+test:
+  @echo The platform `$(DETOURS_TARGET_PROCESSOR)` is not supported.  Skipping.
+clean:
+realclean:
+
+!ENDIF
+
+################################################################# End of File.

--- a/samples/dynamic_alloc/main.cpp
+++ b/samples/dynamic_alloc/main.cpp
@@ -1,0 +1,177 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+//  Detours Test Program
+//
+//  Microsoft Research Detours Package
+//
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//
+#define _CRT_SECURE_NO_WARNINGS
+#include <iostream>
+#include <functional>
+#include <assert.h>
+#include <windows.h>
+#include <detours.h>
+
+extern "C" {
+  void *CodeTemplate();
+  void *CodeTemplate_End();
+}
+
+void Log(LPCTSTR format, ...) {
+  TCHAR linebuf[1024];
+  va_list v;
+  va_start(v, format);
+  wvsprintf(linebuf, format, v);
+  va_end(v);
+  OutputDebugString(linebuf);
+}
+
+void *target_function() {
+  std::cout << '+' << __FUNCTION__ << std::endl;
+  return nullptr;
+}
+
+bool DetourTransaction(std::function<bool()> callback) {
+  LONG status = DetourTransactionBegin();
+  if (status != NO_ERROR) {
+    Log("DetourTransactionBegin failed with %08x\n", status);
+    return status;
+  }
+
+  if (callback()) {
+    status = DetourTransactionCommit();
+    if (status != NO_ERROR) {
+      Log("DetourTransactionCommit failed with %08x\n", status);
+    }
+  }
+  else {
+    status = DetourTransactionAbort();
+    if (status == NO_ERROR) {
+      Log("Aborted transaction.\n");
+    }
+    else {
+      Log("DetourTransactionAbort failed with %08x\n", status);
+    }
+  }
+  return status == NO_ERROR;
+}
+
+class CodeRegionFactory final {
+  template <typename T>
+  static const T *at(const void *base, uint32_t offset) {
+    return
+      reinterpret_cast<const T*>(
+        reinterpret_cast<const uint8_t*>(base) + offset);
+  }
+
+  template <typename T>
+  static T *at(void *base, uint32_t offset) {
+    return
+      reinterpret_cast<T*>(
+        reinterpret_cast<uint8_t*>(base) + offset);
+  }
+
+  void *region_{};
+  uint8_t *current_{},
+          *current_end_{};
+
+public:
+  CodeRegionFactory(const void *source) {
+    DWORD new_region_size{};
+    auto new_region_address =
+      DetourAllocateRegionWithinJumpBounds(source, &new_region_size);
+    if (new_region_address) {
+      region_ = current_ = at<uint8_t>(new_region_address, 0);
+      current_end_ = current_ + new_region_size;
+    }
+    else {
+      Log("Cannot find a region near %p\n", source);
+    }
+  }
+
+  ~CodeRegionFactory() {
+    if (region_
+        && !VirtualFree(region_, 0, MEM_RELEASE)) {
+      Log("VirtualFree failed - %08x\n", GetLastError());
+    }
+  }
+
+  void *PushTemplate(const void *start,
+                     const void *end) {
+    size_t diff =
+      at<uint8_t>(end, 0) - at<uint8_t>(start, 0);
+    if (diff < 0 || current_ + diff > current_end_)
+      return nullptr;
+    auto start_pos = current_;
+    memcpy(start_pos, start, diff);
+    current_ += diff;
+    return start_pos;
+  }
+};
+
+int main(int, char**) {
+  std::cout << "1. target_function() without Detour" << std::endl;
+  auto ret = target_function();
+  std::cout << ret << std::endl;
+  assert(!ret);
+
+  CodeRegionFactory factory(target_function);
+
+  void *detour_destination,
+       *detour_target = reinterpret_cast<void*>(target_function);
+
+  // Fill the allocated page with a code template till the end
+  // and pick the last instance
+  while (auto p = factory.PushTemplate(CodeTemplate,
+                                       CodeTemplate_End)) {
+    detour_destination = p;
+  }
+
+  bool is_detoured = false;
+  DetourTransaction([&]() {
+    PDETOUR_TRAMPOLINE trampoline{};
+    void *target{},
+         *detour{};
+    auto status = DetourAttachEx(&detour_target,
+                                 detour_destination,
+                                 &trampoline,
+                                 &target,
+                                 &detour);
+    if (status != NO_ERROR) {
+      Log("DetourAttachEx failed - %08x\n", status);
+      return false;
+    }
+    is_detoured = true;
+    std::cout
+      << "detour: " << target << " --> " << detour
+      << " (trampoline: " << trampoline << " )"
+      << std::endl;
+    return true;
+  });
+
+  // Attach failed for some reason.  Bail out.
+  if (!is_detoured)
+    return 1;
+
+  std::cout << "2. target_function() with Detour" << std::endl;
+  ret = target_function();
+  std::cout << ret << std::endl;
+  assert(ret); // The return value is cracked by the detour function
+
+  DetourTransaction([&]() {
+    auto status = DetourDetach(&detour_target, detour_destination);
+    if (status != NO_ERROR) {
+      Log("DetourDetach failed - %08x\n", status);
+      return false;
+    }
+    return true;
+  });
+
+  std::cout << "3. target_function() without Detour" << std::endl;
+  ret = target_function();
+  std::cout << ret << std::endl;
+  assert(!ret);
+
+  return 0;
+}

--- a/samples/dynamic_alloc/x64.asm
+++ b/samples/dynamic_alloc/x64.asm
@@ -1,0 +1,25 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;  Detours Test Program
+;;
+;;  Microsoft Research Detours Package
+;;
+;;  Copyright (c) Microsoft Corporation.  All rights reserved.
+;;
+PUBLIC CodeTemplate
+PUBLIC CodeTemplate_End
+
+_TEXT SEGMENT
+
+CodeTemplate PROC
+  nop
+  nop
+  mov rax, 0deadbeef00000000h
+  nop
+  ret
+CodeTemplate_End::
+CodeTemplate ENDP
+
+_TEXT ENDS
+
+END

--- a/samples/dynamic_alloc/x86.asm
+++ b/samples/dynamic_alloc/x86.asm
@@ -1,0 +1,31 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;  Detours Test Program
+;;
+;;  Microsoft Research Detours Package
+;;
+;;  Copyright (c) Microsoft Corporation.  All rights reserved.
+;;
+.386
+.model flat,C
+
+PUBLIC CodeTemplate
+PUBLIC CodeTemplate_End
+
+_TEXT SEGMENT
+
+CodeTemplate PROC
+  nop
+  nop
+  nop
+  mov eax, 0deadbeefh
+  nop
+  nop
+  nop
+  ret
+CodeTemplate_End::
+CodeTemplate ENDP
+
+_TEXT ENDS
+
+END


### PR DESCRIPTION
This patch adds a new sample to test a new API `DetourAllocateRegionWithinJumpBounds` that was introduced by #27.  I'll update the wiki after this PR is done.