### PR TITLE
Fix makefile error message, using the wrong environment variable.

### DIFF
--- a/system.mak
+++ b/system.mak
@@ -88,7 +88,7 @@ DETOURS_OPTION_BITS=64
 !MESSAGE Note: To select the target processor architecture set either
 !MESSAGE       PROCESSOR_ARCHITECTURE or DETOURS_TARGET_PROCESSOR.
 !MESSAGE
-!ERROR Unknown target processor: $(DETOURS_TARGET_ARCHITECTURE)
+!ERROR Unknown target processor: "$(DETOURS_TARGET_PROCESSOR)"
 !ENDIF
 
 ##############################################################################


### PR DESCRIPTION
The error message for unknown target processor was using the DETOURS_TARGET_ARCHITECTURE variable which doesn't exist. appears to be a mistype of DETOURS_TARGET_PROCESSOR