### PR TITLE
Replace implicit type conversion with incorrect semantics by proper return value

### DIFF
--- a/samples/common.mak
+++ b/samples/common.mak
@@ -23,7 +23,7 @@ CLIB=/MT
 !ENDIF
 
 AFLAGS=/nologo /Zi /c /Fl
-CFLAGS=/nologo /Zi $(CLIB) /Gm- /W4 /WX /Od
+CFLAGS=/nologo /Zi $(CLIB) /Gm- /W4 /WX /we4800 /Od
 
 !IF $(DETOURS_SOURCE_BROWSING)==1
 CFLAGS=$(CFLAGS) /FR

--- a/samples/dynamic_alloc/main.cpp
+++ b/samples/dynamic_alloc/main.cpp
@@ -49,7 +49,7 @@ bool DetourTransaction(std::function<bool()> callback) {
   LONG status = DetourTransactionBegin();
   if (status != NO_ERROR) {
     Log("DetourTransactionBegin failed with %08x\n", status);
-    return status;
+    return status == NO_ERROR;
   }
 
   if (callback()) {

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ DETOURS_SOURCE_BROWSING = 0
 
 #######################/#######################################################
 ##
-CFLAGS=/nologo /W4 /WX /Zi /MT /Gy /Gm- /Zl /Od
+CFLAGS=/nologo /W4 /WX /we4800 /Zi /MT /Gy /Gm- /Zl /Od
 
 !IF $(DETOURS_SOURCE_BROWSING)==1
 CFLAGS=$(CFLAGS) /FR


### PR DESCRIPTION
The dynamic_alloc example fails to compile on Visual Studio 2015 due to an C4800 / C2220 compiler error (LONG status is used as return value). Apart from the performance warning, which is treated as error because of the /WX flag, the semantics of this operation seem to be wrong. At the end of the function, we find `return status == NO_ERROR`. That means that in line 70 a successful execution results in a return value of `true` and an unsuccessful execution results in `false`. However, if the function is left in line 52, the return code is `true` (because the test `status != NO_ERROR` was positive).

On the other hand, the return value of the method is nowhere used, so the function signature might just as well be adjusted to use void at this moment.