### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/samples/README.TXT
+++ b/samples/README.TXT
@@ -33,6 +33,18 @@ samples, type "nmake".
 Note that you must build setdll and syslog in order to use many of the
 other sample programs.
 
+INSTALLING AND BUILDING VIA VCPKG:
+==================================
+You can download and install detours using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install detours
+    
+The detours port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 TESTING:
 ========
 Each of the sample directories has a test, which can be invoked by typing


### PR DESCRIPTION
`Detours `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `detours `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `detours`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (Windows: x86, x64, ARM, UWP) to keep a wide coverage for users.
Note: Currently only support dynamic build on Windows.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/detours/portfile.cmake). We try to keep the library maintained as close as possible to the original library.