### PR TITLE
Allow compilation with MinGW to succeed

### DIFF
--- a/src/detours.h
+++ b/src/detours.h
@@ -48,6 +48,12 @@
 #pragma warning(pop)
 #endif
 
+#ifdef __GNUC__
+#define __try
+#define __except(x) if (0)
+#include <strsafe.h>
+#endif
+
 #endif // DETOURS_INTERNAL
 
 //////////////////////////////////////////////////////////////////////////////
@@ -836,7 +842,7 @@ VOID CALLBACK DetourFinishHelperProcess(_In_ HWND,
 
 //////////////////////////////////////////////////////////////////////////////
 //
-#if (_MSC_VER < 1299)
+#if (_MSC_VER < 1299) && !defined(__GNUC__)
 #include <imagehlp.h>
 typedef IMAGEHLP_MODULE IMAGEHLP_MODULE64;
 typedef PIMAGEHLP_MODULE PIMAGEHLP_MODULE64;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -146,6 +146,8 @@ protected:
     DWORD                   m_cbAlloc;
 };
 
+class CImageImportName;
+
 class CImageImportFile
 {
     friend class CImage;

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -340,7 +340,7 @@ PVOID WINAPI DetourGetEntryPoint(_In_opt_ HMODULE hModule)
             }
 
             SetLastError(NO_ERROR);
-            return GetProcAddress(hClr, "_CorExeMain");
+            return (PVOID)GetProcAddress(hClr, "_CorExeMain");
         }
 
         SetLastError(NO_ERROR);


### PR DESCRIPTION
What the title says. MinGW doesn't support `__try` and `__except`, so it's just defined out here as it doesn't seem there's a better way to handle it.

Note: Includes #107 