### PR TITLE
Fix typo “Window Store apps”

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and allows the community to support Detours using open source tools and processe
 
 Detours is compatible with the Windows NT family of 
 operating systems: Windows NT, Windows XP, Windows Server 2003, Windows 7,
-Windows 8, and Windows 10.  It cannot be used by Window Store apps
+Windows 8, and Windows 10.  It cannot be used by Windows Store apps
 because Detours requires APIs not available to those applications. 
 This repo contains the source code for version 4.0.1 of Detours.
 


### PR DESCRIPTION
There is a typo that reads “ It cannot be used by Window Store apps”. Fixed to read “...Windows Store apps”