### PR TITLE
Add IsWow64ProcessHelper function

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -505,6 +505,9 @@ static BOOL IsWow64ProcessHelper(HANDLE hProcess,
                                  PBOOL Wow64Process)
 {
 #ifdef _X86_
+    UNREFERENCED_PARAMETER(hProcess);
+    UNREFERENCED_PARAMETER(Wow64Process);
+    
     return FALSE;
 #else
     if (Wow64Process == NULL) {

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -504,6 +504,9 @@ typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
 static BOOL IsWow64ProcessHelper(HANDLE hProcess,
                                  PBOOL Wow64Process)
 {
+#ifdef _X86_
+    return FALSE;
+#else
     if (Wow64Process == NULL) {
         return FALSE;
     }
@@ -526,6 +529,7 @@ static BOOL IsWow64ProcessHelper(HANDLE hProcess,
         return FALSE;
     }
     return pfnIsWow64Process(hProcess, Wow64Process);
+#endif
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -499,8 +499,6 @@ static BOOL UpdateFrom32To64(HANDLE hProcess, HMODULE hModule, WORD machine,
 }
 #endif // DETOURS_64BIT
 
-typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
-
 static BOOL IsWow64ProcessHelper(HANDLE hProcess,
                                  PBOOL Wow64Process)
 {
@@ -510,28 +508,7 @@ static BOOL IsWow64ProcessHelper(HANDLE hProcess,
     
     return FALSE;
 #else
-    if (Wow64Process == NULL) {
-        return FALSE;
-    }
-
-    // IsWow64Process is not available on all supported versions of Windows.
-    // Use GetModuleHandle to get a handle to the DLL that contains the function
-    // and GetProcAddress to get a pointer to the function if available.
-    //
-    HMODULE hKernel32 = GetModuleHandleW(L"KERNEL32.DLL");
-    if (hKernel32 == NULL) {
-        DETOUR_TRACE(("GetModuleHandleW failed: %d\n", GetLastError()));
-        return FALSE;
-    }
-
-    LPFN_ISWOW64PROCESS pfnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(
-        hKernel32, "IsWow64Process");
-
-    if (pfnIsWow64Process == NULL) {
-        DETOUR_TRACE(("GetProcAddress failed: %d\n", GetLastError()));
-        return FALSE;
-    }
-    return pfnIsWow64Process(hProcess, Wow64Process);
+    return IsWow64Process(hProcess, Wow64Process);
 #endif
 }
 

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -499,14 +499,32 @@ static BOOL UpdateFrom32To64(HANDLE hProcess, HMODULE hModule, WORD machine,
 }
 #endif // DETOURS_64BIT
 
+typedef BOOL(WINAPI *LPFN_ISWOW64PROCESS)(HANDLE, PBOOL);
+
 static BOOL IsWow64ProcessHelper(HANDLE hProcess,
                                  PBOOL Wow64Process)
 {
 #ifdef _X86_
-    UNREFERENCED_PARAMETER(hProcess);
-    UNREFERENCED_PARAMETER(Wow64Process);
-    
-    return FALSE;
+    if (Wow64Process == NULL) {
+        return FALSE;
+    }
+
+    // IsWow64Process is not available on all supported versions of Windows.
+    //
+    HMODULE hKernel32 = LoadLibraryW(L"KERNEL32.DLL");
+    if (hKernel32 == NULL) {
+        DETOUR_TRACE(("LoadLibraryW failed: %d\n", GetLastError()));
+        return FALSE;
+    }
+
+    LPFN_ISWOW64PROCESS pfnIsWow64Process = (LPFN_ISWOW64PROCESS)GetProcAddress(
+        hKernel32, "IsWow64Process");
+
+    if (pfnIsWow64Process == NULL) {
+        DETOUR_TRACE(("GetProcAddress failed: %d\n", GetLastError()));
+        return FALSE;
+    }
+    return pfnIsWow64Process(hProcess, Wow64Process);
 #else
     return IsWow64Process(hProcess, Wow64Process);
 #endif


### PR DESCRIPTION
I needed to compile Detours with VS 2005, which doesn't include `IsWow64Process` in its Windows SDK, so added a small wrapper function around it using `GetModuleHandleW` and `GetProcAddress`.

Used the [example on MSDN](https://docs.microsoft.com/en-us/windows/win32/api/wow64apiset/nf-wow64apiset-iswow64process#examples) as a reference.