### PR TITLE
Define `_KERNEL32_` and `_USER32_` for the sake of users providing kernel32/user32 functionality for themselves.

### DIFF
--- a/src/detours.h
+++ b/src/detours.h
@@ -28,6 +28,15 @@
 #pragma warning(disable:4091) // empty typedef
 #endif
 
+// Suppress declspec(dllimport) for the sake of Detours
+// users that provide kernel32 functionality themselves.
+// This is ok in the mainstream case, it will just cost
+// an extra instruction calling some functions, which
+// LTCG optimizes away.
+//
+#define _KERNEL32_ 1
+#define _USER32_ 1
+
 #include <windows.h>
 #if (_MSC_VER < 1310)
 #else


### PR DESCRIPTION
Define `_KERNEL32_` and `_USER32_` for the sake of users providing kernel32/user32 functionality for themselves.
This is not hypothetical. This fixed our own build breaks.

Mainstream users will suffer acceptably, one extra instruction on some calls, which LTCG optimizes away, if you actually care about performance. And function pointer comparisons kinda won't work, and nobody cares (each .dll gets own single instruction stub, instead of reading through the pointer to the main implementation).