### PR TITLE
Initial CI workflow for Detours

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: CI-Build
+
+env:
+  # Turn on msvc analysis during build.
+  DETOURS_ANALYZE: true
+  # Compile in parallel where possible.
+  CL: /MP
+
+# Triggers the workflow on push or pull request events for the master branch.
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        # ARM/ARM64 don't build/link, omit [amd64_arm, amd64_arm64] for now..
+        arch: [x64, x86]
+
+    steps:
+    - uses: actions/checkout@v2
+
+      # Setup build environment variables using vcvarsall.bat.
+    - uses: ilammy/msvc-dev-cmd@v1.3.0
+      with:
+        arch: ${{ matrix.arch }}
+
+    - name: Build ${{ matrix.arch }}
+      run: nmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: CI-Build
 
 env:
-  # Turn on msvc analysis during build.
-  DETOURS_ANALYZE: true
+  # Turn on msvc analysis during build, enable once warnings are clean.
+  # DETOURS_ANALYZE: true
+
   # Compile in parallel where possible.
   CL: /MP
 
@@ -22,12 +23,35 @@ jobs:
         arch: [x64, x86]
 
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # Must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head of the pull request.
+          # Only include this option if you are running this workflow on pull requests.
+          fetch-depth: 2
+
+      # If this run was triggered by a pull request event then checkout
+      # the head of the pull request instead of the merge commit.
+      # Only include this step if you are running this workflow on pull requests.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
 
       # Setup build environment variables using vcvarsall.bat.
-    - uses: ilammy/msvc-dev-cmd@v1.3.0
-      with:
-        arch: ${{ matrix.arch }}
+      - name: Configure MSCV Compiler
+        uses: ilammy/msvc-dev-cmd@v1.3.0
+        with:
+          arch: ${{ matrix.arch }}
 
-    - name: Build ${{ matrix.arch }}
-      run: nmake
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: cpp
+
+      # Actually run the build
+      - name: Build ${{ matrix.arch }}
+        run: nmake
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/samples/common.mak
+++ b/samples/common.mak
@@ -80,7 +80,7 @@ LIBS = $(DEPS)
 !endif
 
 .rc{$(OBJD)}.res:
-    rc /DDETOURS_BITS=$(DETOURS_BITS) /fo$(@) /i$(INCD) $(*B).rc
+    rc /nologo /DDETOURS_BITS=$(DETOURS_BITS) /fo$(@) /i$(INCD) $(*B).rc
 
 ##
 ################################################################# End of File.

--- a/samples/traceapi/_win32.cpp
+++ b/samples/traceapi/_win32.cpp
@@ -4319,8 +4319,10 @@ BOOL (__stdcall * Real_GetThreadContext)(HANDLE a0,
 HDESK (__stdcall * Real_GetThreadDesktop)(DWORD a0)
     = GetThreadDesktop;
 
+#if(WINVER >= 0x0500)
 LCID (__stdcall * Real_GetThreadLocale)(void)
     = GetThreadLocale;
+#endif // (WINVER >= 0x0500)
 
 int (__stdcall * Real_GetThreadPriority)(HANDLE a0)
     = GetThreadPriority;
@@ -7046,8 +7048,10 @@ DWORD (__stdcall * Real_SetThreadIdealProcessor)(HANDLE a0,
                                                  DWORD a1)
     = SetThreadIdealProcessor;
 
+#if(WINVER >= 0x0500)
 BOOL (__stdcall * Real_SetThreadLocale)(LCID a0)
     = SetThreadLocale;
+#endif // (WINVER >= 0x0500)
 
 BOOL (__stdcall * Real_SetThreadPriority)(HANDLE a0,
                                           int a1)
@@ -21338,6 +21342,7 @@ HDESK __stdcall Mine_GetThreadDesktop(DWORD a0)
     return rv;
 }
 
+#if(WINVER >= 0x0500)
 LCID __stdcall Mine_GetThreadLocale(void)
 {
     _PrintEnter("GetThreadLocale()\n");
@@ -21350,6 +21355,7 @@ LCID __stdcall Mine_GetThreadLocale(void)
     };
     return rv;
 }
+#endif // (WINVER >= 0x0500)
 
 int __stdcall Mine_GetThreadPriority(HANDLE a0)
 {
@@ -29382,6 +29388,7 @@ DWORD __stdcall Mine_SetThreadIdealProcessor(HANDLE a0,
     return rv;
 }
 
+#if(WINVER >= 0x0500)
 BOOL __stdcall Mine_SetThreadLocale(LCID a0)
 {
     _PrintEnter("SetThreadLocale(%p)\n", a0);
@@ -29394,6 +29401,7 @@ BOOL __stdcall Mine_SetThreadLocale(LCID a0)
     };
     return rv;
 }
+#endif // (WINVER >= 0x0500)
 
 BOOL __stdcall Mine_SetThreadPriority(HANDLE a0,
                                       int a1)
@@ -34541,7 +34549,9 @@ LONG AttachDetours(VOID)
     ATTACH(GetTextMetricsW);
     ATTACH(GetThreadContext);
     ATTACH(GetThreadDesktop);
+#if(WINVER >= 0x0500)
     ATTACH(GetThreadLocale);
+#endif // (WINVER >= 0x0500)
     ATTACH(GetThreadPriority);
     ATTACH(GetThreadPriorityBoost);
     ATTACH(GetThreadSelectorEntry);
@@ -35083,7 +35093,9 @@ LONG AttachDetours(VOID)
     ATTACH(SetThreadContext);
     ATTACH(SetThreadDesktop);
     ATTACH(SetThreadIdealProcessor);
+#if(WINVER >= 0x0500)
     ATTACH(SetThreadLocale);
+#endif // (WINVER >= 0x0500)
     ATTACH(SetThreadPriority);
     ATTACH(SetThreadPriorityBoost);
     ATTACH(SetTimeZoneInformation);
@@ -36218,7 +36230,9 @@ LONG DetachDetours(VOID)
     DETACH(GetTextMetricsW);
     DETACH(GetThreadContext);
     DETACH(GetThreadDesktop);
+#if(WINVER >= 0x0500)
     DETACH(GetThreadLocale);
+#endif // (WINVER >= 0x0500)
     DETACH(GetThreadPriority);
     DETACH(GetThreadPriorityBoost);
     DETACH(GetThreadSelectorEntry);
@@ -36760,7 +36774,9 @@ LONG DetachDetours(VOID)
     DETACH(SetThreadContext);
     DETACH(SetThreadDesktop);
     DETACH(SetThreadIdealProcessor);
+#if(WINVER >= 0x0500)
     DETACH(SetThreadLocale);
+#endif // (WINVER >= 0x0500)
     DETACH(SetThreadPriority);
     DETACH(SetThreadPriorityBoost);
     DETACH(SetTimeZoneInformation);

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ DETOURS_SOURCE_BROWSING = 0
 
 #######################/#######################################################
 ##
-CFLAGS=/W4 /WX /Zi /MT /Gy /Gm- /Zl /Od
+CFLAGS=/nologo /W4 /WX /Zi /MT /Gy /Gm- /Zl /Od
 
 !IF $(DETOURS_SOURCE_BROWSING)==1
 CFLAGS=$(CFLAGS) /FR
@@ -90,7 +90,7 @@ $(OBJD)\detours.bsc : $(OBJS)
     bscmake /v /n /o $@ $(OBJS:.obj=.sbr)
 
 $(LIBD)\detours.lib : $(OBJS)
-    link /lib /out:$@ $(OBJS)
+    link /lib /out:$@ /nologo $(OBJS)
 
 $(INCD)\detours.h : detours.h
     copy detours.h $@


### PR DESCRIPTION
Add a simple workflow that builds x86 and x64 build architectures on push to master, or to validate pull requests.
It currently builds with MSVC:
- x64
- x86

It also runs CodeQL analysis with the build, so we can get further static analysis from the CodeQL rule-sets.

In order to get the code building in on the latest Windows Kit SDK, I had restrict the use of GetThreadLocale/SetThreadlocale
under WINVER guard, as the SDK headers introduced the same check.

I've also included a commit to disable more logo banners, as that seems to be the convention in the rest of the build. 