### PR TITLE
Build: Detect DETOURS_TARGET_PROCESSOR from VS Developer Command Prompt

### DIFF
--- a/samples/disas/Makefile
+++ b/samples/disas/Makefile
@@ -7,10 +7,10 @@
 ##  Copyright (c) Microsoft Corporation.  All rights reserved.
 ##
 
+!include ..\common.mak
+
 # temporarily disable this test for ARM64
 !if "$(DETOURS_TARGET_PROCESSOR)" != "ARM64"
-
-!include ..\common.mak
 
 LIBS=$(LIBS) kernel32.lib
 

--- a/system.mak
+++ b/system.mak
@@ -8,7 +8,14 @@
 ##
 
 ############################################## Determine Processor Build Type.
-##
+#
+# Default the detours architecture to match the compiler target that
+# has been selected by the user via the VS Developer Command Prompt
+# they launched.
+!IF "$(DETOURS_TARGET_PROCESSOR)" == "" && "$(VSCMD_ARG_TGT_ARCH)" != ""
+DETOURS_TARGET_PROCESSOR = $(VSCMD_ARG_TGT_ARCH)
+!ENDIF
+
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "" && "$(PROCESSOR_ARCHITEW6432)" != ""
 DETOURS_TARGET_PROCESSOR = X86
 !ENDIF
@@ -17,7 +24,7 @@ DETOURS_TARGET_PROCESSOR = X86
 DETOURS_TARGET_PROCESSOR = $(PROCESSOR_ARCHITECTURE)
 !ENDIF
 
-# uppercase DETOURS_TARGET_PROCESSOR
+# Uppercase DETOURS_TARGET_PROCESSOR
 DETOURS_TARGET_PROCESSOR=$(DETOURS_TARGET_PROCESSOR:a=A)
 DETOURS_TARGET_PROCESSOR=$(DETOURS_TARGET_PROCESSOR:b=B)
 DETOURS_TARGET_PROCESSOR=$(DETOURS_TARGET_PROCESSOR:c=C)
@@ -63,7 +70,7 @@ DETOURS_BITS=64
 ## DETOURS_OPTION_PROCESSOR: Set this macro if the processor *will* run code
 ##                           from another ISA (i.e. x86 on x64).
 ##
-##      DETOURS_OPTION_BITS: Set this macro if the processor *may* have an
+##      DETOURS_OPTION_BITS: Set this macro if the processor *may* have
 ##                           an alternative word size.
 ##
 !IF "$(DETOURS_TARGET_PROCESSOR)" == "X64"


### PR DESCRIPTION
The VS Developer command prompts sets two variables based on the configuration
which was launched. One is the architecture of the host compiler, the other is
the architecture that the compiler is targeting.

```
C:\> set | rg VSCMD_ARG_
VSCMD_ARG_HOST_ARCH=x64
VSCMD_ARG_TGT_ARCH=x86
```

`$(VSCMD_ARG_TGT_ARCH)` is a direct mapping to what the user is expected to set
the `$(DETOURS_TARGET_PROCESSOR)` environment variable too. For cross compilation
and normal compilation the variable is always set to the value that is expected.

This change uses this to our advantage so that users won't have to manually set
the `$(DETOURS_TARGET_PROCESSOR)` variable in order to compile.