### PR TITLE
Build: Catch incorrect format specifiers with /we4777 and fix issues.

### DIFF
--- a/samples/comeasy/wrotei.cpp
+++ b/samples/comeasy/wrotei.cpp
@@ -101,7 +101,7 @@ int WINAPI TimedEntryPoint(VOID)
     }
     else {
         printf("wrotei" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
-               " Error detouring IStram::Wrote(): %d\n", error);
+               " Error detouring IStram::Wrote(): %ld\n", error);
     }
 
     printf("wrotei" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
@@ -143,7 +143,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         }
         else {
             printf("wrotei" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
-                   " Error detouring EntryPoint(): %d\n", error);
+                   " Error detouring EntryPoint(): %ld\n", error);
         }
     }
     else if (dwReason == DLL_PROCESS_DETACH) {
@@ -156,7 +156,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         error = DetourTransactionCommit();
 
         printf("wrotei" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
-               " Removed IStream::Wrote() detours (%d), wrote %d bytes.\n",
+               " Removed IStream::Wrote() detours (%ld), wrote %ld bytes.\n",
                error, dwWrote);
 
         fflush(stdout);

--- a/samples/commem/commem.cpp
+++ b/samples/commem/commem.cpp
@@ -48,9 +48,9 @@ HRESULT STDMETHODCALLTYPE MineIStreamWrite(IStream * This,
         pcbWritten = &cbWritten;
     }
 
-    printf("commem:   %p->IStreamWrite(pv=%p, cb=%d)\n", This, pv, cb);
+    printf("commem:   %p->IStreamWrite(pv=%p, cb=%ld)\n", This, pv, cb);
     hr = RealIStreamWrite(This, pv, cb, pcbWritten);
-    printf("commem:   %p->IStreamWrite -> %08x (pcbWritten=%d)\n", This, hr, *pcbWritten);
+    printf("commem:   %p->IStreamWrite -> %08lx (pcbWritten=%ld)\n", This, hr, *pcbWritten);
 
     return hr;
 }

--- a/samples/common.mak
+++ b/samples/common.mak
@@ -23,7 +23,7 @@ CLIB=/MT
 !ENDIF
 
 AFLAGS=/nologo /Zi /c /Fl
-CFLAGS=/nologo /Zi $(CLIB) /Gm- /W4 /WX /Od
+CFLAGS=/nologo /Zi $(CLIB) /Gm- /W4 /WX /we4777 /Od
 
 !IF $(DETOURS_SOURCE_BROWSING)==1
 CFLAGS=$(CFLAGS) /FR

--- a/samples/cping/cping.cpp
+++ b/samples/cping/cping.cpp
@@ -130,7 +130,7 @@ VOID PingAssertMessage(CONST PCHAR szMsg, CONST PCHAR szFile, ULONG nLine)
 {
     PingMessage("%08lx ASSERT(%s) failed in %s, line %d.\n",
                 GetCurrentThreadId(), szMsg, szFile, nLine);
-    printf("ASSERT(%s) failed in %s, line %d.\n", szMsg, szFile, nLine);
+    printf("ASSERT(%s) failed in %s, line %ld.\n", szMsg, szFile, nLine);
 }
 
 BOOLEAN CheckResult(HRESULT hr, PCSTR pszMsg, ...)
@@ -341,7 +341,7 @@ VOID ZeroCycles(VOID)
 VOID DumpCycles(LONG nRoute)
 {
     if (s_rllCycles[nRoute] != 0 || s_rllTotals[nRoute] != 0) {
-        printf(";;   %-21.21s %10I64d %8.3fms %10I64d %8.3fms :%6d\n",
+        printf(";;   %-21.21s %10I64d %8.3fms %10I64d %8.3fms :%6ld\n",
                s_rszRouteNames[nRoute],
                s_rllCycles[nRoute], (double)s_rllCycles[nRoute] * g_dMsPerCycle,
                s_rllTotals[nRoute], (double)s_rllTotals[nRoute] * g_dMsPerCycle,
@@ -1456,7 +1456,7 @@ HRESULT CSampleRecord::Write()
     FileTimeToLocalFileTime(&m_nWhen, &ft);
     FileTimeToSystemTime(&ft, &st);
 
-    printf("%02d/%02d %2d:%02d:%02d %6d %d %6.3f [ %6.3f %6.3f %6.3f %6.3f ]\n",
+    printf("%02d/%02d %2d:%02d:%02d %6ld %ld %6.3f [ %6.3f %6.3f %6.3f %6.3f ]\n",
            st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond,
            m_cbToClient, m_cbToServer, m_dTime,
            m_dDcom, m_dRpc, m_dUdp, m_dNet);
@@ -1479,10 +1479,10 @@ double NetTest(HKEY hNetwork, IPing *pIPing,
     ULONG nMin = 999;
 
     if (fToClient) {
-        printf(">Client %6d %6d ", cbPacket, nCount);
+        printf(">Client %6ld %6ld ", cbPacket, nCount);
     }
     else {
-        printf(">Server %6d %6d ", cbPacket, nCount);
+        printf(">Server %6ld %6ld ", cbPacket, nCount);
     }
 
     for (LONG n = 0; n < nCount; n++) {
@@ -1545,7 +1545,7 @@ double NetTest(HKEY hNetwork, IPing *pIPing,
         RegSetValueW(hNetwork, wzKey, REG_SZ, wzLatency, (DWORD)wcssize(wzLatency));
     }
 
-    printf("%8.3f %8.3f %8.3f %9.4f %8.3f %9.4f%3d\n",
+    printf("%8.3f %8.3f %8.3f %9.4f %8.3f %9.4f%3ld\n",
            msMin,
            msAvg,
            msMax,
@@ -1602,7 +1602,7 @@ void Sample_Fixed(IPing *pIPing)
     }
 
     dAvg /= 512;
-    printf("size: %d, min: %.3f, max: %.3f avg: %.3f [ %8.3f %8.3f %8.3f %8.3f ]\n",
+    printf("size: %ld, min: %.3f, max: %.3f avg: %.3f [ %8.3f %8.3f %8.3f %8.3f ]\n",
            g_nFixedToClient, dMin, dMax, dAvg, dMinDcom, dMinRpc, dMinUdp, dMinNet);
     for (int n = 0; n < nRecords; n++) {
         csrRecords[n].Write();

--- a/samples/disas/disas.cpp
+++ b/samples/disas/disas.cpp
@@ -510,7 +510,7 @@ int WINAPI WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR lpszCmdLine, int nCmd
     printf("%p:\n", pbBegin);
     for (PBYTE pbTest = pbBegin;;) {
         if (pbTest[0] != 0xcc) {    // int 3
-            printf("%08x  ", (ULONG)(pbTest - pbBegin));
+            printf("%08lx  ", (ULONG)(pbTest - pbBegin));
             DumpMemoryFragment(pbTest, 8, 8);
             printf("\n");
             printf("failed on last.\n");
@@ -530,7 +530,7 @@ int WINAPI WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR lpszCmdLine, int nCmd
 
         LONG cbTest = (LONG)(pbNext - pbTest);
 
-        printf("%08x  ", (ULONG)(pbTest - pbBegin));
+        printf("%08lx  ", (ULONG)(pbTest - pbBegin));
         DumpMemoryFragment(pbTest, cbTest, 12);
         printf("[%16p] ", pbTarget);
         DumpMemoryFragment(rbDst, cbTest + lExtra, 11);

--- a/samples/dtest/dtarge.cpp
+++ b/samples/dtest/dtarge.cpp
@@ -18,28 +18,28 @@ DWORD_PTR WINAPI Target0()
 
 DWORD_PTR WINAPI Target1(DWORD_PTR v1)
 {
-    printf("    Target1 (%d)\n",
+    printf("    Target1 (%ld)\n",
            (DWORD)v1);
     return 1001;
 }
 
 DWORD_PTR WINAPI Target2(DWORD_PTR v1, DWORD_PTR v2)
 {
-    printf("    Target2 (%d,%d)\n",
+    printf("    Target2 (%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2);
     return 1002;
 }
 
 DWORD_PTR WINAPI Target3(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3)
 {
-    printf("    Target3 (%d,%d,%d)\n",
+    printf("    Target3 (%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3);
     return 1003;
 }
 
 DWORD_PTR WINAPI Target4(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4)
 {
-    printf("    Target4 (%d,%d,%d,%d)\n",
+    printf("    Target4 (%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4);
     return 1004;
 }
@@ -47,7 +47,7 @@ DWORD_PTR WINAPI Target4(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4)
 DWORD_PTR WINAPI Target5(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                          DWORD_PTR v5)
 {
-    printf("    Target5 (%d,%d,%d,%d,%d)\n",
+    printf("    Target5 (%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5);
     return 1005;
@@ -56,7 +56,7 @@ DWORD_PTR WINAPI Target5(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
 DWORD_PTR WINAPI Target6(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                          DWORD_PTR v5, DWORD_PTR v6)
 {
-    printf("    Target6 (%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target6 (%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6);
     return 1006;
@@ -65,7 +65,7 @@ DWORD_PTR WINAPI Target6(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
 DWORD_PTR WINAPI Target7(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                          DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7)
 {
-    printf("    Target7 (%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target7 (%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7);
     return 1007;
@@ -74,7 +74,7 @@ DWORD_PTR WINAPI Target7(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
 DWORD_PTR WINAPI Target8(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                          DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8)
 {
-    printf("    Target8 (%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target8 (%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8);
     return 1008;
@@ -84,7 +84,7 @@ DWORD_PTR WINAPI Target9(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                          DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                          DWORD_PTR v9)
 {
-    printf("    Target9 (%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target9 (%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9);
@@ -95,7 +95,7 @@ DWORD_PTR WINAPI Target10(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4
                           DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                           DWORD_PTR v9, DWORD_PTR v10)
 {
-    printf("    Target10(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target10(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10);
@@ -106,7 +106,7 @@ DWORD_PTR WINAPI Target11(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4
                           DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                           DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11)
 {
-    printf("    Target11(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target11(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11);
@@ -117,7 +117,7 @@ DWORD_PTR WINAPI Target12(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4
                           DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                           DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12)
 {
-    printf("    Target12(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target12(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12);
@@ -129,7 +129,7 @@ DWORD_PTR WINAPI Target13(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4
                           DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                           DWORD_PTR v13)
 {
-    printf("    Target13(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target13(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -142,7 +142,7 @@ DWORD_PTR WINAPI Target14(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4
                           DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                           DWORD_PTR v13, DWORD_PTR v14)
 {
-    printf("    Target14(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target14(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -155,7 +155,7 @@ DWORD_PTR WINAPI Target15(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4
                           DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                           DWORD_PTR v13, DWORD_PTR v14, DWORD_PTR v15)
 {
-    printf("    Target15(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target15(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -168,7 +168,7 @@ DWORD_PTR WINAPI Target16(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4
                           DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                           DWORD_PTR v13, DWORD_PTR v14, DWORD_PTR v15, DWORD_PTR v16)
 {
-    printf("    Target16(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("    Target16(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -192,9 +192,9 @@ DWORD_PTR WINAPI TargetV(DWORD_PTR v1, ...)
     printf("    TargetV (");
     int i = argc - 1;
     for (; i > 0; i--) {
-        printf("%d,", (DWORD)args[i]);
+        printf("%ld,", (DWORD)args[i]);
     }
-    printf("%d)\n", (DWORD)args[0]);
+    printf("%ld)\n", (DWORD)args[0]);
 
     return 1000 + argc;
 }
@@ -285,9 +285,9 @@ DWORD_PTR WINAPI TargetR(DWORD_PTR v1, ...)
     printf("    TargetR (");
     int i = argc - 1;
     for (; i > 0; i--) {
-        printf("%d,", (DWORD)args[i]);
+        printf("%ld,", (DWORD)args[i]);
     }
-    printf("%d)\n", (DWORD)args[0]);
+    printf("%ld)\n", (DWORD)args[0]);
 
     return 2000 + argc;
 }

--- a/samples/dtest/dtest.cpp
+++ b/samples/dtest/dtest.cpp
@@ -100,7 +100,7 @@ VOID dprintf(const char * fmt, ...)
 //
 DWORD_PTR WINAPI LocalTarget1(DWORD_PTR v1)
 {
-    printf("  LocalTarget1 (%d)\n", (DWORD)v1);
+    printf("  LocalTarget1 (%ld)\n", (DWORD)v1);
     // dprintf("LocalTarget1\n");
     // __debugbreak();
     return 9000;
@@ -110,7 +110,7 @@ DWORD_PTR WINAPI LocalTarget1(DWORD_PTR v1)
 //
 DWORD_PTR WINAPI MyLocalTarget1(DWORD_PTR v1)
 {
-    printf("  MyLocalTarget1 (%d)\n",
+    printf("  MyLocalTarget1 (%ld)\n",
            (DWORD)v1);
     // dprintf("LocalTarget1, Trampoline_LocalTarget1=%p\n", Trampoline_LocalTarget1);
     return Trampoline_LocalTarget1(v1);
@@ -124,28 +124,28 @@ DWORD_PTR WINAPI MyTarget0()
 
 DWORD_PTR WINAPI MyTarget1(DWORD_PTR v1)
 {
-    printf("  MyTarget1 (%d)\n",
+    printf("  MyTarget1 (%ld)\n",
            (DWORD)v1);
     return Trampoline_Target1(v1);
 }
 
 DWORD_PTR WINAPI MyTarget2(DWORD_PTR v1, DWORD_PTR v2)
 {
-    printf("  MyTarget2 (%d,%d)\n",
+    printf("  MyTarget2 (%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2);
     return Trampoline_Target2(v1,v2);
 }
 
 DWORD_PTR WINAPI MyTarget3(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3)
 {
-    printf("  MyTarget3 (%d,%d,%d)\n",
+    printf("  MyTarget3 (%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3);
     return Trampoline_Target3(v1,v2,v3);
 }
 
 DWORD_PTR WINAPI MyTarget4(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4)
 {
-    printf("  MyTarget4 (%d,%d,%d,%d)\n",
+    printf("  MyTarget4 (%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4);
     return Trampoline_Target4(v1,v2,v3,v4);
 }
@@ -153,7 +153,7 @@ DWORD_PTR WINAPI MyTarget4(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v
 DWORD_PTR WINAPI MyTarget5(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                            DWORD_PTR v5)
 {
-    printf("  MyTarget5 (%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget5 (%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5);
     return Trampoline_Target5(v1,v2,v3,v4,v5);
@@ -162,7 +162,7 @@ DWORD_PTR WINAPI MyTarget5(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v
 DWORD_PTR WINAPI MyTarget6(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                            DWORD_PTR v5, DWORD_PTR v6)
 {
-    printf("  MyTarget6 (%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget6 (%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6);
     return Trampoline_Target6(v1,v2,v3,v4,v5,v6);
@@ -171,7 +171,7 @@ DWORD_PTR WINAPI MyTarget6(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v
 DWORD_PTR WINAPI MyTarget7(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                            DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7)
 {
-    printf("  MyTarget7 (%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget7 (%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7);
     return Trampoline_Target7(v1,v2,v3,v4,v5,v6,v7);
@@ -180,7 +180,7 @@ DWORD_PTR WINAPI MyTarget7(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v
 DWORD_PTR WINAPI MyTarget8(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v4,
                            DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8)
 {
-    printf("  MyTarget8 (%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget8 (%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8);
     return Trampoline_Target8(v1,v2,v3,v4,v5,v6,v7,v8);
@@ -190,7 +190,7 @@ DWORD_PTR WINAPI MyTarget9(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR v
                          DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                          DWORD_PTR v9)
 {
-    printf("  MyTarget9 (%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget9 (%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9);
@@ -201,7 +201,7 @@ DWORD_PTR WINAPI MyTarget10(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR 
                             DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                             DWORD_PTR v9, DWORD_PTR v10)
 {
-    printf("  MyTarget10(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget10(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10);
@@ -212,7 +212,7 @@ DWORD_PTR WINAPI MyTarget11(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR 
                             DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                             DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11)
 {
-    printf("  MyTarget11(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget11(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11);
@@ -223,7 +223,7 @@ DWORD_PTR WINAPI MyTarget12(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR 
                             DWORD_PTR v5, DWORD_PTR v6, DWORD_PTR v7, DWORD_PTR v8,
                             DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12)
 {
-    printf("  MyTarget12(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget12(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12);
@@ -235,7 +235,7 @@ DWORD_PTR WINAPI MyTarget13(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR 
                             DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                             DWORD_PTR v13)
 {
-    printf("  MyTarget13(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget13(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -248,7 +248,7 @@ DWORD_PTR WINAPI MyTarget14(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR 
                             DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                             DWORD_PTR v13, DWORD_PTR v14)
 {
-    printf("  MyTarget14(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget14(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -261,7 +261,7 @@ DWORD_PTR WINAPI MyTarget15(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR 
                             DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                             DWORD_PTR v13, DWORD_PTR v14, DWORD_PTR v15)
 {
-    printf("  MyTarget15(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget15(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -274,7 +274,7 @@ DWORD_PTR WINAPI MyTarget16(DWORD_PTR v1, DWORD_PTR v2, DWORD_PTR v3, DWORD_PTR 
                             DWORD_PTR v9, DWORD_PTR v10, DWORD_PTR v11, DWORD_PTR v12,
                             DWORD_PTR v13, DWORD_PTR v14, DWORD_PTR v15, DWORD_PTR v16)
 {
-    printf("  MyTarget16(%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d)\n",
+    printf("  MyTarget16(%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld,%ld)\n",
            (DWORD)v1, (DWORD)v2, (DWORD)v3, (DWORD)v4,
            (DWORD)v5, (DWORD)v6, (DWORD)v7, (DWORD)v8,
            (DWORD)v9, (DWORD)v10, (DWORD)v11, (DWORD)v12,
@@ -298,9 +298,9 @@ DWORD_PTR WINAPI MyTargetV(DWORD_PTR v1, ...)
     printf("  MyTargetV (");
     int i = argc - 1;
     for (; i > 0; i--) {
-        printf("%d,", (DWORD)args[i]);
+        printf("%ld,", (DWORD)args[i]);
     }
-    printf("%d)\n", (DWORD)args[0]);
+    printf("%ld)\n", (DWORD)args[0]);
 
     switch (argc) {
       default:
@@ -387,9 +387,9 @@ DWORD_PTR WINAPI MyTargetR(DWORD_PTR v1, ...)
         printf("  MyTargetR (");
         int i = argc - 1;
         for (; i > 0; i--) {
-            printf("%d,", (DWORD)args[i]);
+            printf("%ld,", (DWORD)args[i]);
         }
-        printf("%d)\n", (DWORD)args[0]);
+        printf("%ld)\n", (DWORD)args[0]);
     }
     else {
         printf(".");
@@ -583,7 +583,7 @@ int WINAPI WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR lpszCmdLine, int nCmd
     TargetV(16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0);
     TargetR(4,3,2,1,0);
     DWORD_PTR rv = TargetR(100,10,9,8,7,6,5,4,3,2,1,0);
-    printf(" => %d\n", (DWORD)rv);
+    printf(" => %ld\n", (DWORD)rv);
 
     Trampoline_Target0_1 = Target0;
     Trampoline_Target0_2 = Target0;

--- a/samples/dumpe/dumpe.cpp
+++ b/samples/dumpe/dumpe.cpp
@@ -39,7 +39,7 @@ do { if (!(x)) { DetourAssertMessage(#x, __FILE__, __LINE__); PCHAR p=(PCHAR)(x)
 //
 VOID DetourAssertMessage(CONST PCHAR szMsg, CONST PCHAR szFile, DWORD nLine)
 {
-    printf("ASSERT(%s) failed in %s, line %d.", szMsg, szFile, nLine);
+    printf("ASSERT(%s) failed in %s, line %ld.", szMsg, szFile, nLine);
 }
 
 
@@ -51,7 +51,7 @@ static BOOL CALLBACK ExportCallback(PVOID pContext,
 {
     (void)pContext;
 
-    printf("    %7d      %p %-30s\n",
+    printf("    %7ld      %p %-30s\n",
            (ULONG)nOrdinal,
            pbTarget,
            pszSymbol ? pszSymbol : "[NONAME]");
@@ -62,7 +62,7 @@ BOOL DumpFile(PCHAR pszPath)
 {
     HINSTANCE hInst = LoadLibraryA(pszPath);
     if (hInst == NULL) {
-        printf("Unable to load %s: Error %d\n", pszPath, GetLastError());
+        printf("Unable to load %s: Error %ld\n", pszPath, GetLastError());
         return FALSE;
     }
 

--- a/samples/dumpi/dumpi.cpp
+++ b/samples/dumpi/dumpi.cpp
@@ -22,7 +22,7 @@
 //
 VOID AssertMessage(PCSTR szMsg, PCSTR szFile, DWORD nLine)
 {
-    printf("ASSERT(%s) failed in %s, line %d.", szMsg, szFile, nLine);
+    printf("ASSERT(%s) failed in %s, line %ld.", szMsg, szFile, nLine);
 }
 
 #define ASSERT(x)   \
@@ -72,7 +72,7 @@ BOOL CALLBACK ListSymbolCallback(_In_opt_ PVOID pContext,
     *pnOutOrdinal = 0;
 
     if (nOrigOrdinal != 0) {
-        printf("  %s::#%d\n",
+        printf("  %s::#%ld\n",
                s_szFile, nOrigOrdinal);
     }
     else {
@@ -99,14 +99,14 @@ BOOL DimpFile(PCHAR pszPath)
                        NULL);
 
     if (hOld == INVALID_HANDLE_VALUE) {
-        printf("%s: Failed to open input file with error: %d\n",
+        printf("%s: Failed to open input file with error: %ld\n",
                pszPath, GetLastError());
         bGood = FALSE;
         goto end;
     }
 
     if ((pBinary = DetourBinaryOpen(hOld)) == NULL) {
-        printf("%s: DetourBinaryOpen failed: %d\n", pszPath, GetLastError());
+        printf("%s: DetourBinaryOpen failed: %ld\n", pszPath, GetLastError());
         goto end;
     }
 
@@ -123,7 +123,7 @@ BOOL DimpFile(PCHAR pszPath)
                                  ListSymbolCallback,
                                  NULL)) {
 
-        printf("%s: DetourBinaryEditImports failed: %d\n", pszPath, GetLastError());
+        printf("%s: DetourBinaryEditImports failed: %ld\n", pszPath, GetLastError());
     }
 
     DetourBinaryClose(pBinary);

--- a/samples/echo/echofx.cpp
+++ b/samples/echo/echofx.cpp
@@ -43,7 +43,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         }
         else {
             printf("echofx" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
-                   " Error detouring Echo(): %d\n", error);
+                   " Error detouring Echo(): %ld\n", error);
         }
     }
     else if (dwReason == DLL_PROCESS_DETACH) {
@@ -53,7 +53,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         error = DetourTransactionCommit();
 
         printf("echofx" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
-               " Removed Echo() (result=%d)\n", error);
+               " Removed Echo() (result=%ld)\n", error);
         fflush(stdout);
     }
     return TRUE;

--- a/samples/excep/excep.cpp
+++ b/samples/excep/excep.cpp
@@ -22,7 +22,7 @@ static DWORD    s_dwDataPerm = 0;
 
 static LONG ExceptCatch(LONG nTry, DWORD dwException, LPEXCEPTION_POINTERS pinfo)
 {
-    printf("      ExceptCatch(%d, %08x, %08x)\n", nTry, dwException, (ULONG)pinfo);
+    printf("      ExceptCatch(%ld, %08lx, %08lx)\n", nTry, dwException, (ULONG)pinfo);
 #ifdef INCLUDE_THIS
     if (nTry == 0) {
         return EXCEPTION_CONTINUE_EXECUTION;
@@ -34,11 +34,11 @@ static LONG ExceptCatch(LONG nTry, DWORD dwException, LPEXCEPTION_POINTERS pinfo
 static int BadCode(int nTry)
 {
     printf("    BadCode(Try:%d)\n", nTry);
-    printf("      BadCode -> %d\n", *(PULONG)s_pvData);
+    printf("      BadCode -> %ld\n", *(PULONG)s_pvData);
     ((PULONG)s_pvData)[0] = 0;
-    printf("      BadCode -> %d\n", *(PULONG)s_pvData);
+    printf("      BadCode -> %ld\n", *(PULONG)s_pvData);
     ((PULONG)s_pvData)[-1] = 0;
-    printf("      BadCode -> %d\n", *(PULONG)s_pvData);
+    printf("      BadCode -> %ld\n", *(PULONG)s_pvData);
 
     return 0;
 }
@@ -54,7 +54,7 @@ void safe(int nTry)
                            GetExceptionInformation())) {
         DWORD dwExcept = GetExceptionCode();
 
-        printf("  handler(%d) : %08x\n", nTry, dwExcept);
+        printf("  handler(%d) : %08lx\n", nTry, dwExcept);
     }
 }
 
@@ -90,7 +90,7 @@ int WINAPI WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR lpszCmdLine, int nCmd
 
     s_pvData = VirtualAlloc(NULL, sizeof(ULONG), MEM_RESERVE|MEM_COMMIT, PAGE_READWRITE);
     if (s_pvData == NULL) {
-        printf("VirtualAlloc failed: %d\n", GetLastError());
+        printf("VirtualAlloc failed: %ld\n", GetLastError());
         return 0;
     }
     *(PULONG)s_pvData = 1;

--- a/samples/findfunc/extend.cpp
+++ b/samples/findfunc/extend.cpp
@@ -24,9 +24,9 @@ static DWORD WINAPI Extend(DWORD dwCount)
 {
     InterlockedIncrement(&nExtends);
 
-    printf("extend.dll: Extend    (%d) -> %d.\n", dwCount, dwCount + 1000);
+    printf("extend.dll: Extend    (%ld) -> %ld.\n", dwCount, dwCount + 1000);
     dwCount = TrueTarget(dwCount + 1000);
-    printf("extend.dll: Extend    (.....) -> %d.\n", dwCount);
+    printf("extend.dll: Extend    (.....) -> %ld.\n", dwCount);
     return dwCount;
 }
 
@@ -35,9 +35,9 @@ static DWORD WINAPI Intern(DWORD dwCount)
 {
     InterlockedIncrement(&nInterns);
 
-    printf("extend.dll:    Intern (%d) -> %d.\n", dwCount, dwCount + 10);
+    printf("extend.dll:    Intern (%ld) -> %ld.\n", dwCount, dwCount + 10);
     dwCount = TrueHidden(dwCount + 10);
-    printf("extend.dll:    Intern (.....) -> %d.\n", dwCount);
+    printf("extend.dll:    Intern (.....) -> %ld.\n", dwCount);
     return dwCount;
 }
 
@@ -60,7 +60,7 @@ static int WINAPI ExtendEntryPoint()
         printf("extend.dll: Detoured Target().\n");
     }
     else {
-        printf("extend.dll: Error detouring Target(): %d\n", error);
+        printf("extend.dll: Error detouring Target(): %ld\n", error);
     }
 
     // Now try to detour the functions requiring debug symbols.
@@ -69,7 +69,7 @@ static int WINAPI ExtendEntryPoint()
         DetourFindFunction("target.dll", "Hidden");
     if (TrueHidden == NULL) {
         error = GetLastError();
-        printf("extend.dll: TrueHidden = %p (error = %d)\n", TrueHidden, error);
+        printf("extend.dll: TrueHidden = %p (error = %ld)\n", TrueHidden, error);
     }
 
     DetourTransactionBegin();
@@ -81,7 +81,7 @@ static int WINAPI ExtendEntryPoint()
         printf("extend.dll: Detoured Hidden().\n");
     }
     else {
-        printf("extend.dll: Error detouring Hidden(): %d\n", error);
+        printf("extend.dll: Error detouring Hidden(): %ld\n", error);
     }
 
     // Now let the application start executing.
@@ -120,7 +120,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
             printf("extend.dll: Detoured EntryPoint().\n");
         }
         else {
-            printf("extend.dll: Error detouring EntryPoint(): %d\n", error);
+            printf("extend.dll: Error detouring EntryPoint(): %ld\n", error);
         }
     }
     else if (dwReason == DLL_PROCESS_DETACH) {
@@ -141,7 +141,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         DetourDetach(&(PVOID&)TrueEntryPoint, ExtendEntryPoint);
         error = DetourTransactionCommit();
 
-        printf("extend.dll: Removed Target() detours (%d), %d/%d calls.\n",
+        printf("extend.dll: Removed Target() detours (%ld), %ld/%ld calls.\n",
                error, nExtends, nInterns);
 
         fflush(stdout);

--- a/samples/findfunc/findfunc.cpp
+++ b/samples/findfunc/findfunc.cpp
@@ -26,7 +26,7 @@ int __cdecl main(void)
 
     DWORD dwCount = 10000;
     for (int i = 0; i < 3; i++) {
-        printf("findfunc.exe: Calling (%d).\n", dwCount);
+        printf("findfunc.exe: Calling (%ld).\n", dwCount);
         dwCount = Target(dwCount) + 10000;
     }
     return 0;

--- a/samples/findfunc/symtest.cpp
+++ b/samples/findfunc/symtest.cpp
@@ -139,21 +139,21 @@ BOOL WINAPI CallbackFunction(HANDLE hProcess, ULONG action, ULONG64 data, ULONG6
         return TRUE;
 
       case CBA_DEFERRED_SYMBOL_LOAD_CANCEL:
-        printf("::> proc=%p action=%08x data=%p\n",
+        printf("::> proc=%p action=%08lx data=%p\n",
                       (PVOID)hProcess,
                       action,
                       (PVOID)data);
         {
             PIMAGEHLP_DEFERRED_SYMBOL_LOAD64 pi = (PIMAGEHLP_DEFERRED_SYMBOL_LOAD64)data;
-            printf("pi->SizeOfStruct = %d\n", pi->SizeOfStruct);
+            printf("pi->SizeOfStruct = %ld\n", pi->SizeOfStruct);
             printf("pi->BaseOfImage  = %p\n", (PVOID)(size_t)pi->BaseOfImage);
-            printf("pi->CheckSum     = %8x\n", pi->CheckSum);
+            printf("pi->CheckSum     = %8lx\n", pi->CheckSum);
             printf("pi->FileName     = %p [%s]\n", pi->FileName, pi->FileName);
             printf("pi->Reparse      = %d\n", pi->Reparse);
         }
         return FALSE;
       default:
-        printf("::> proc=%p action=%08x data=%p\n",
+        printf("::> proc=%p action=%08lx data=%p\n",
                       (PVOID)hProcess,
                       action,
                       (PVOID)data);
@@ -212,7 +212,7 @@ int __cdecl main(void)
                   API_VERSION_NUMBER);
 
     if (!pfSymInitialize(hProcess, NULL, FALSE)) {
-        printf("SymInitialize failed: %d\n", GetLastError());
+        printf("SymInitialize failed: %ld\n", GetLastError());
         return 1;
     }
 
@@ -221,7 +221,7 @@ int __cdecl main(void)
 #endif
 
     DWORD dw = pfSymGetOptions();
-    printf("GetOptions = %08x\n", dw);
+    printf("GetOptions = %08lx\n", dw);
     dw &= ~(SYMOPT_CASE_INSENSITIVE |
             SYMOPT_UNDNAME |
             SYMOPT_DEFERRED_LOADS |
@@ -243,7 +243,7 @@ int __cdecl main(void)
            SYMOPT_INCLUDE_32BIT_MODULES |
 #endif
            0);
-    printf("SetOptions = %08x\n", dw);
+    printf("SetOptions = %08lx\n", dw);
     pfSymSetOptions(dw);
 
     /////////////////////////////////////////////// First, try GetProcAddress.
@@ -251,7 +251,7 @@ int __cdecl main(void)
     PCHAR pszFile = "target.dll";
     HMODULE hModule = LoadLibraryA(pszFile);
     if (hModule == NULL) {
-        printf("LoadLibraryA(%s) failed: %d\n", pszFile, GetLastError());
+        printf("LoadLibraryA(%s) failed: %ld\n", pszFile, GetLastError());
         return 2;
     }
 
@@ -266,7 +266,7 @@ int __cdecl main(void)
                                        (PCHAR)pszFile/*szFull*/, NULL,
                                        (DWORD64)hModule, 0);
     if (loaded == 0) {
-        printf("SymLoadModule64(%p) failed: %d\n", hProcess, GetLastError());
+        printf("SymLoadModule64(%p) failed: %ld\n", hProcess, GetLastError());
         printf("\n");
     }
     else {
@@ -285,16 +285,16 @@ int __cdecl main(void)
     ZeroMemory(&modinfo, sizeof(modinfo));
     modinfo.SizeOfStruct = 512/*sizeof(modinfo)*/;
     if (!pfSymGetModuleInfo64(hProcess, (DWORD64)hModule, &modinfo)) {
-        printf("SymGetModuleInfo64(%p, %p) [64] failed: %d\n",
+        printf("SymGetModuleInfo64(%p, %p) [64] failed: %ld\n",
                       hProcess, hModule, GetLastError());
     }
     else {
-        printf("SymGetModuleInfo64(%p, %p) [64] succeeded: %d\n",
+        printf("SymGetModuleInfo64(%p, %p) [64] succeeded: %ld\n",
                       hProcess, hModule, GetLastError());
         StringCchCopyA(szModName, ARRAYSIZE(szModName), modinfo.ModuleName);
         StringCchCatA(szModName, ARRAYSIZE(szModName), "!");
 
-        printf("NumSyms:         %d\n", modinfo.NumSyms);
+        printf("NumSyms:         %ld\n", modinfo.NumSyms);
         printf("SymType:         %d\n", modinfo.SymType);
         printf("ModuleName:      %s\n", modinfo.ModuleName);
         printf("ImageName:       %s\n", modinfo.ImageName);
@@ -319,7 +319,7 @@ int __cdecl main(void)
         SetLastError(0);
         nSymbolCount = 0;
         if (!pfSymEnumSymbols(hProcess, (DWORD64)hModule, NULL, SymEnumerateSymbols, NULL)) {
-            printf("SymEnumSymbols() failed: %d\n",
+            printf("SymEnumSymbols() failed: %ld\n",
                           GetLastError());
         }
     }
@@ -345,7 +345,7 @@ int __cdecl main(void)
 
     SetLastError(0);
     if (!pfSymFromName(hProcess, szFullName, &symbol)) {
-        printf("--SymFromName(%s) failed: %d\n", szFullName, GetLastError());
+        printf("--SymFromName(%s) failed: %ld\n", szFullName, GetLastError());
     }
     if (symbol.Address != 0) {
         printf("--SymFromName(%s) succeeded\n", szFullName);
@@ -368,7 +368,7 @@ int __cdecl main(void)
 
     SetLastError(0);
     if (!pfSymFromName(hProcess, szFullName, &symbol)) {
-        printf("--SymFromName(%s) failed: %d\n", szFullName, GetLastError());
+        printf("--SymFromName(%s) failed: %ld\n", szFullName, GetLastError());
     }
     if (symbol.Address != 0) {
         printf("--SymFromName(%s) succeeded\n", szFullName);

--- a/samples/findfunc/target.cpp
+++ b/samples/findfunc/target.cpp
@@ -13,7 +13,7 @@
 
 extern "C" DWORD WINAPI Hidden(DWORD dwCount)
 {
-    printf("target.dll:     Hidden(%d) -> %d.\n", dwCount, dwCount + 1);
+    printf("target.dll:     Hidden(%ld) -> %ld.\n", dwCount, dwCount + 1);
     return dwCount + 1;
 }
 
@@ -22,9 +22,9 @@ static DWORD (WINAPI * SelfHidden)(DWORD dwCount) = Hidden;
 
 DWORD WINAPI Target(DWORD dwCount)
 {
-    printf("target.dll:   Target  (%d) -> %d.\n", dwCount, dwCount + 100);
+    printf("target.dll:   Target  (%ld) -> %ld.\n", dwCount, dwCount + 100);
     dwCount = SelfHidden(dwCount + 100);
-    printf("target.dll:   Target  (.....) -> %d.\n", dwCount);
+    printf("target.dll:   Target  (.....) -> %ld.\n", dwCount);
     return dwCount;
 }
 

--- a/samples/impmunge/impmunge.cpp
+++ b/samples/impmunge/impmunge.cpp
@@ -23,7 +23,7 @@
 //
 VOID AssertMessage(PCSTR szMsg, PCSTR szFile, DWORD nLine)
 {
-    printf("ASSERT(%s) failed in %s, line %d.", szMsg, szFile, nLine);
+    printf("ASSERT(%s) failed in %s, line %ld.", szMsg, szFile, nLine);
 }
 
 #define ASSERT(x)   \
@@ -267,14 +267,14 @@ BOOL EditFile(PCHAR pszInput, PCHAR pszOutput)
                        NULL);
 
     if (hOld == INVALID_HANDLE_VALUE) {
-        printf("Couldn't open input file: %s, error: %d\n",
+        printf("Couldn't open input file: %s, error: %ld\n",
                pszInput, GetLastError());
         fGood = FALSE;
         goto end;
     }
 
     if ((pBinary = DetourBinaryOpen(hOld)) == NULL) {
-        printf("DetourBinaryOpen failed: %d\n", GetLastError());
+        printf("DetourBinaryOpen failed: %ld\n", GetLastError());
         goto end;
     }
 
@@ -291,7 +291,7 @@ BOOL EditFile(PCHAR pszInput, PCHAR pszOutput)
                                      RestoreSymbol,
                                      RestoreCommit)) {
 
-            printf("DetourBinaryEditImports for munge failed: %d\n", GetLastError());
+            printf("DetourBinaryEditImports for munge failed: %ld\n", GetLastError());
         }
     }
 
@@ -307,7 +307,7 @@ BOOL EditFile(PCHAR pszInput, PCHAR pszOutput)
                                      MungeSymbol,
                                      MungeCommit)) {
 
-            printf("DetourBinaryEditImports for munge failed: %d\n", GetLastError());
+            printf("DetourBinaryEditImports for munge failed: %ld\n", GetLastError());
         }
     }
 
@@ -319,7 +319,7 @@ BOOL EditFile(PCHAR pszInput, PCHAR pszOutput)
                                      ListSymbol,
                                      ListCommit)) {
 
-            printf("DetourBinaryEditImports for list failed: %d\n", GetLastError());
+            printf("DetourBinaryEditImports for list failed: %ld\n", GetLastError());
         }
     }
 
@@ -328,14 +328,14 @@ BOOL EditFile(PCHAR pszInput, PCHAR pszOutput)
                            GENERIC_WRITE | GENERIC_READ, 0, NULL, CREATE_ALWAYS,
                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
         if (hNew == INVALID_HANDLE_VALUE) {
-            printf("Couldn't open output file: %s, error: %d\n",
+            printf("Couldn't open output file: %s, error: %ld\n",
                    pszOutput, GetLastError());
             fGood = FALSE;
             goto end;
         }
 
         if (!DetourBinaryWrite(pBinary, hNew)) {
-            printf("DetourBinaryWrite failed: %d\n", GetLastError());
+            printf("DetourBinaryWrite failed: %ld\n", GetLastError());
             fGood = FALSE;
         }
 
@@ -349,7 +349,7 @@ BOOL EditFile(PCHAR pszInput, PCHAR pszOutput)
 
     if (fGood && pszOutput != NULL) {
         if (!BindImageEx(BIND_NO_BOUND_IMPORTS, pszOutput, ".", ".", NULL)) {
-            printf("Warning: Couldn't bind binary %s: %d\n", pszOutput, GetLastError());
+            printf("Warning: Couldn't bind binary %s: %ld\n", pszOutput, GetLastError());
         }
     }
 

--- a/samples/member/member.cpp
+++ b/samples/member/member.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
                  *(PBYTE*)&pfMine);
 
     LONG l = DetourTransactionCommit();
-    printf("DetourTransactionCommit = %d\n", l);
+    printf("DetourTransactionCommit = %ld\n", l);
     printf("\n");
 
     Verify("CMember::Target      ", *(PBYTE*)&pfTarget);

--- a/samples/region/region.cpp
+++ b/samples/region/region.cpp
@@ -22,7 +22,7 @@ DWORD WINAPI LoudSleepEx(DWORD dwMilliseconds, BOOL bAlertable)
     DWORD ret = TrueSleepEx(dwMilliseconds, bAlertable);
     DWORD dwEnd = GetTickCount();
 
-    printf("Slept %u ticks.\n", dwEnd - dwBeg);
+    printf("Slept %lu ticks.\n", dwEnd - dwBeg);
     return ret;
 }
 
@@ -38,12 +38,12 @@ PVOID AttachAndDetach(DWORD dwMilliseconds)
     DetourAttach(&(PVOID&)TrueSleepEx, LoudSleepEx);
     error = DetourTransactionCommit();
 
-    printf("Attach: %d, Trampoline: %p\n", error, TrueSleepEx);
+    printf("Attach: %ld, Trampoline: %p\n", error, TrueSleepEx);
 
     trampoline = TrueSleepEx;
 
     printf("\n");
-    printf("Sleep(%u)\n", dwMilliseconds);
+    printf("Sleep(%lu)\n", dwMilliseconds);
     Sleep(dwMilliseconds);
     printf("\n");
 

--- a/samples/setdll/setdll.cpp
+++ b/samples/setdll/setdll.cpp
@@ -22,7 +22,7 @@
 //
 VOID AssertMessage(PCSTR szMsg, PCSTR szFile, DWORD nLine)
 {
-    printf("ASSERT(%s) failed in %s, line %d.", szMsg, szFile, nLine);
+    printf("ASSERT(%s) failed in %s, line %ld.", szMsg, szFile, nLine);
 }
 
 #define ASSERT(x)   \
@@ -60,7 +60,7 @@ BOOL DoesDllExportOrdinal1(PCHAR pszDllPath)
 {
     HMODULE hDll = LoadLibraryExA(pszDllPath, NULL, DONT_RESOLVE_DLL_REFERENCES);
     if (hDll == NULL) {
-        printf("setdll.exe: LoadLibraryEx(%s) failed with error %d.\n",
+        printf("setdll.exe: LoadLibraryEx(%s) failed with error %ld.\n",
                pszDllPath,
                GetLastError());
         return FALSE;
@@ -141,7 +141,7 @@ BOOL SetFile(PCHAR pszPath)
                        NULL);
 
     if (hOld == INVALID_HANDLE_VALUE) {
-        printf("Couldn't open input file: %s, error: %d\n",
+        printf("Couldn't open input file: %s, error: %ld\n",
                szOrg, GetLastError());
         bGood = FALSE;
         goto end;
@@ -151,14 +151,14 @@ BOOL SetFile(PCHAR pszPath)
                        GENERIC_WRITE | GENERIC_READ, 0, NULL, CREATE_ALWAYS,
                        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
     if (hNew == INVALID_HANDLE_VALUE) {
-        printf("Couldn't open output file: %s, error: %d\n",
+        printf("Couldn't open output file: %s, error: %ld\n",
                szNew, GetLastError());
         bGood = FALSE;
         goto end;
     }
 
     if ((pBinary = DetourBinaryOpen(hOld)) == NULL) {
-        printf("DetourBinaryOpen failed: %d\n", GetLastError());
+        printf("DetourBinaryOpen failed: %ld\n", GetLastError());
         goto end;
     }
 
@@ -176,7 +176,7 @@ BOOL SetFile(PCHAR pszPath)
             if (!DetourBinaryEditImports(pBinary,
                                          &bAddedDll,
                                          AddBywayCallback, NULL, NULL, NULL)) {
-                printf("DetourBinaryEditImports failed: %d\n", GetLastError());
+                printf("DetourBinaryEditImports failed: %ld\n", GetLastError());
             }
         }
 
@@ -184,11 +184,11 @@ BOOL SetFile(PCHAR pszPath)
                                      ListBywayCallback, ListFileCallback,
                                      NULL, NULL)) {
 
-            printf("DetourBinaryEditImports failed: %d\n", GetLastError());
+            printf("DetourBinaryEditImports failed: %ld\n", GetLastError());
         }
 
         if (!DetourBinaryWrite(pBinary, hNew)) {
-            printf("DetourBinaryWrite failed: %d\n", GetLastError());
+            printf("DetourBinaryWrite failed: %ld\n", GetLastError());
             bGood = FALSE;
         }
 
@@ -204,17 +204,17 @@ BOOL SetFile(PCHAR pszPath)
             if (!DeleteFileA(szOld)) {
                 DWORD dwError = GetLastError();
                 if (dwError != ERROR_FILE_NOT_FOUND) {
-                    printf("Warning: Couldn't delete %s: %d\n", szOld, dwError);
+                    printf("Warning: Couldn't delete %s: %ld\n", szOld, dwError);
                     bGood = FALSE;
                 }
             }
             if (!MoveFileA(szOrg, szOld)) {
-                printf("Error: Couldn't back up %s to %s: %d\n",
+                printf("Error: Couldn't back up %s to %s: %ld\n",
                        szOrg, szOld, GetLastError());
                 bGood = FALSE;
             }
             if (!MoveFileA(szNew, szOrg)) {
-                printf("Error: Couldn't install %s as %s: %d\n",
+                printf("Error: Couldn't install %s as %s: %ld\n",
                        szNew, szOrg, GetLastError());
                 bGood = FALSE;
             }

--- a/samples/simple/simple.cpp
+++ b/samples/simple/simple.cpp
@@ -56,7 +56,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         }
         else {
             printf("simple" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
-                   " Error detouring SleepEx(): %d\n", error);
+                   " Error detouring SleepEx(): %ld\n", error);
         }
     }
     else if (dwReason == DLL_PROCESS_DETACH) {
@@ -66,7 +66,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         error = DetourTransactionCommit();
 
         printf("simple" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:"
-               " Removed SleepEx() (result=%d), slept %d ticks.\n", error, dwSlept);
+               " Removed SleepEx() (result=%ld), slept %ld ticks.\n", error, dwSlept);
         fflush(stdout);
     }
     return TRUE;

--- a/samples/slept/dslept.cpp
+++ b/samples/slept/dslept.cpp
@@ -65,7 +65,7 @@ int WINAPI TimedEntryPoint(VOID)
     }
     else {
         printf("dslept" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: "
-               " Error detouring SleepEx(): %d\n", error);
+               " Error detouring SleepEx(): %ld\n", error);
     }
 
     Verify("SleepEx", (PVOID)SleepEx);
@@ -118,7 +118,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         }
         else {
             printf("dslept" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: "
-                   " Error detouring EntryPoint(): %d\n", error);
+                   " Error detouring EntryPoint(): %ld\n", error);
         }
     }
     else if (dwReason == DLL_PROCESS_DETACH) {
@@ -131,7 +131,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         error = DetourTransactionCommit();
 
         printf("dslept" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: "
-               " Removed Sleep() detours (%d), slept %d ticks.\n", error, dwSlept);
+               " Removed Sleep() detours (%ld), slept %ld ticks.\n", error, dwSlept);
 
         fflush(stdout);
     }

--- a/samples/slept/sleepbed.cpp
+++ b/samples/slept/sleepbed.cpp
@@ -92,11 +92,11 @@ int __cdecl main(void)
     DetourUpdateThread(GetCurrentThread());
     DetourDetach(&(PVOID&)TrueSleepEx, TimedSleepEx);
     error = DetourTransactionCommit();
-    printf("sleepbed.exe: Removed SleepEx() detour (%d), slept %d ticks.\n",
+    printf("sleepbed.exe: Removed SleepEx() detour (%d), slept %ld ticks.\n",
            error, dwSlept);
     fflush(stdout);
 
-    printf("sleepbed.exe: GetSleptTicks() = %d\n\n", GetSleptTicks());
+    printf("sleepbed.exe: GetSleptTicks() = %ld\n\n", GetSleptTicks());
     return error;
 }
 //

--- a/samples/slept/sleepnew.cpp
+++ b/samples/slept/sleepnew.cpp
@@ -69,7 +69,7 @@ int __cdecl main(void)
     }
 #endif
 
-    printf("sleepnew.exe: GetSleptTicks() = %d\n\n", GetSleptTicks());
+    printf("sleepnew.exe: GetSleptTicks() = %ld\n\n", GetSleptTicks());
     return 0;
 }
 //

--- a/samples/slept/slept.cpp
+++ b/samples/slept/slept.cpp
@@ -111,7 +111,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         }
         else {
             printf("slept" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: "
-                   " Error detouring SleepEx(): %d\n", error);
+                   " Error detouring SleepEx(): %ld\n", error);
         }
     }
     else if (dwReason == DLL_PROCESS_DETACH) {
@@ -120,7 +120,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         DetourDetach(&(PVOID&)TrueSleepEx, TimedSleepEx);
         error = DetourTransactionCommit();
         printf("slept" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: "
-               " Removed SleepEx() detour (%d), slept %d ticks.\n", error, dwSlept);
+               " Removed SleepEx() detour (%ld), slept %ld ticks.\n", error, dwSlept);
         fflush(stdout);
     }
     return TRUE;

--- a/samples/syelog/sltestp.cpp
+++ b/samples/syelog/sltestp.cpp
@@ -22,7 +22,7 @@
 
 VOID MyErrExit(PCSTR pszMsg)
 {
-    fprintf(stderr, "Error %s: %d\n", pszMsg, GetLastError());
+    fprintf(stderr, "Error %s: %ld\n", pszMsg, GetLastError());
     exit(1);
 }
 

--- a/samples/syelog/syelogd.cpp
+++ b/samples/syelog/syelogd.cpp
@@ -58,7 +58,7 @@ VOID MyErrExit(PCSTR pszMsg)
     DWORD error = GetLastError();
 
     LogMessageV(SYELOG_SEVERITY_FATAL, "Error %d in %s.", error, pszMsg);
-    fprintf(stderr, "SYELOGD: Error %d in %s.\n", error, pszMsg);
+    fprintf(stderr, "SYELOGD: Error %ld in %s.\n", error, pszMsg);
     fflush(stderr);
     exit(1);
 }
@@ -501,7 +501,7 @@ DWORD main(int argc, char **argv)
                                      FILE_FLAG_SEQUENTIAL_SCAN,
                                      NULL);
             if (s_hOutFile == INVALID_HANDLE_VALUE) {
-                printf("SYELOGD: Error opening output file: %s: %d\n\n",
+                printf("SYELOGD: Error opening output file: %s: %ld\n\n",
                        argv[arg], GetLastError());
                 fNeedHelp = TRUE;
                 break;

--- a/samples/talloc/talloc.cpp
+++ b/samples/talloc/talloc.cpp
@@ -227,7 +227,7 @@ BOOL DumpProcess(UINT64 lo64, UINT64 hi64)
             }
         }
 
-        printf("%c %12Ix %12Ix: %3s %3s %4s %3s : %s\n",
+        printf("%c %12zx %12zx: %3s %3s %4s %3s : %s\n",
                " *"[base == (size_t)mbi.AllocationBase],
                base,
                size,
@@ -415,7 +415,7 @@ int WINAPI WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR lpszCmdLine, int nCmd
     error = DetourTransactionCommit();
     if (error != NO_ERROR) {
       failed:
-        printf("talloc.exe: Error detouring functions: %d\n", error);
+        printf("talloc.exe: Error detouring functions: %ld\n", error);
         exit(1);
     }
 
@@ -487,17 +487,17 @@ int WINAPI WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR lpszCmdLine, int nCmd
     printf("\n");
 
     DumpProcessHeaders();
-    printf("%-47s %17Ix\n", "Exe:", (size_t)GetModuleHandleW(NULL));
+    printf("%-47s %17zx\n", "Exe:", (size_t)GetModuleHandleW(NULL));
     DumpProcess(0x100000000, 0x200000000);
-    printf("%-47s %17Ix\n", "Dll1:", Dll1);
+    printf("%-47s %17zx\n", "Dll1:", Dll1);
     DumpProcess(0x200000000, 0x300000000);
-    printf("%-47s %17Ix\n", "Dll2:", Dll2);
+    printf("%-47s %17zx\n", "Dll2:", Dll2);
     DumpProcess(0x300000000, 0x400000000);
-    printf("%-47s %17Ix\n", "Dll3:", Dll3);
+    printf("%-47s %17zx\n", "Dll3:", Dll3);
     DumpProcess(0x400000000, 0x500000000);
-    printf("%-47s %17Ix\n", "Dll4:", Dll4);
+    printf("%-47s %17zx\n", "Dll4:", Dll4);
     DumpProcess(0x500000000, 0x600000000);
-    printf("%-47s %17Ix\n", "Dll5:", Dll5);
+    printf("%-47s %17zx\n", "Dll5:", Dll5);
     DumpProcess(0x600000000, 0x700000000);
     fflush(stdout);
 
@@ -531,7 +531,7 @@ int WINAPI WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR lpszCmdLine, int nCmd
     }
 
     printf("\n");
-    printf("talloc.exe: %d calls to Dll1Function\n", dwCountDll1);
+    printf("talloc.exe: %ld calls to Dll1Function\n", dwCountDll1);
     fflush(stdout);
 
     return 0;

--- a/samples/traceapi/_win32.cpp
+++ b/samples/traceapi/_win32.cpp
@@ -35377,7 +35377,7 @@ LONG AttachDetours(VOID)
     PVOID *ppbFailedPointer = NULL;
     LONG error = DetourTransactionCommitEx(&ppbFailedPointer);
     if (error != 0) {
-        printf("traceapi.dll: Attach transaction failed to commit. Error %d (%p/%p)",
+        printf("traceapi.dll: Attach transaction failed to commit. Error %ld (%p/%p)",
                error, ppbFailedPointer, *ppbFailedPointer);
         return error;
     }
@@ -37059,7 +37059,7 @@ LONG DetachDetours(VOID)
         PVOID *ppbFailedPointer = NULL;
         LONG error = DetourTransactionCommitEx(&ppbFailedPointer);
 
-        printf("traceapi.dll: Detach transaction failed to commit. Error %d (%p/%p)",
+        printf("traceapi.dll: Detach transaction failed to commit. Error %ld (%p/%p)",
                error, ppbFailedPointer, *ppbFailedPointer);
         return error;
     }

--- a/samples/tracebld/tracebld.cpp
+++ b/samples/tracebld/tracebld.cpp
@@ -81,7 +81,7 @@ VOID MyErrExit(PCSTR pszMsg)
 {
     DWORD error = GetLastError();
 
-    fprintf(stderr, "TRACEBLD: Error %d in %s.\n", error, pszMsg);
+    fprintf(stderr, "TRACEBLD: Error %ld in %s.\n", error, pszMsg);
     fflush(stderr);
     exit(1);
 }
@@ -207,7 +207,7 @@ PCLIENT CreatePipeConnection(HANDLE hCompletionPort, LONG nClient)
                                  FILE_FLAG_SEQUENTIAL_SCAN,
                                  NULL);
     if (pClient->hFile == INVALID_HANDLE_VALUE) {
-        fprintf(stderr, "TRACEBLD: Error opening output file: %s: %d\n\n",
+        fprintf(stderr, "TRACEBLD: Error opening output file: %s: %ld\n\n",
                 szLogFile, GetLastError());
         fflush(stderr);
         MyErrExit("CreateFile");
@@ -527,7 +527,7 @@ DWORD main(int argc, char **argv)
     if (!DetourCreateProcessWithDllExA(szFullExe[0] ? szFullExe : NULL, szCommand,
                                        NULL, NULL, TRUE, dwFlags, NULL, NULL,
                                        &si, &pi, szDllPath, NULL)) {
-        printf("TRACEBLD: DetourCreateProcessWithDllEx failed: %d\n", GetLastError());
+        printf("TRACEBLD: DetourCreateProcessWithDllEx failed: %ld\n", GetLastError());
         ExitProcess(9007);
     }
 
@@ -547,7 +547,7 @@ DWORD main(int argc, char **argv)
 
     if (!DetourCopyPayloadToProcess(pi.hProcess, s_guidTrace,
                                     &s_Payload, sizeof(s_Payload))) {
-        printf("TRACEBLD: DetourCopyPayloadToProcess failed: %d\n", GetLastError());
+        printf("TRACEBLD: DetourCopyPayloadToProcess failed: %ld\n", GetLastError());
         ExitProcess(9008);
     }
 
@@ -557,11 +557,11 @@ DWORD main(int argc, char **argv)
 
     DWORD dwResult = 0;
     if (!GetExitCodeProcess(pi.hProcess, &dwResult)) {
-        printf("TRACEBLD: GetExitCodeProcess failed: %d\n", GetLastError());
+        printf("TRACEBLD: GetExitCodeProcess failed: %ld\n", GetLastError());
         return 9008;
     }
 
-    printf("TRACEBLD: %d processes.\n", s_nTotalClients);
+    printf("TRACEBLD: %ld processes.\n", s_nTotalClients);
 
     return dwResult;
 }

--- a/samples/tryman/size.cpp
+++ b/samples/tryman/size.cpp
@@ -75,7 +75,7 @@ int __cdecl main(int argc, char **argv)
                         NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
         DWORD dwError = GetLastError();
         printf("size" DETOURS_STRINGIFY(DETOURS_BITS) ".exe:"
-               " CreateProcess failed: %d\n", dwError);
+               " CreateProcess failed: %ld\n", dwError);
         return 1;
     }
 
@@ -84,7 +84,7 @@ int __cdecl main(int argc, char **argv)
     DWORD dwResult = 0;
     if (!GetExitCodeProcess(pi.hProcess, &dwResult)) {
         printf("size" DETOURS_STRINGIFY(DETOURS_BITS) ".exe:"
-               " GetExitCodeProcess failed: %d\n", GetLastError());
+               " GetExitCodeProcess failed: %ld\n", GetLastError());
         return 9010;
     }
 

--- a/samples/tryman/tstman.cpp
+++ b/samples/tryman/tstman.cpp
@@ -309,7 +309,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
             printf("Detoured EntryPoint().\n");
         }
         else {
-            printf("Error detouring EntryPoint(): %d (@ %p)\n", error, RawEntryPoint);
+            printf("Error detouring EntryPoint(): %ld (@ %p)\n", error, RawEntryPoint);
             __debugbreak();
         }
     }
@@ -323,7 +323,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         LONG error = DetourTransactionCommit();
 
         if (error != NO_ERROR) {
-            printf("Error detach detours failed: %d\n", error);
+            printf("Error detach detours failed: %ld\n", error);
         }
     }
 

--- a/samples/withdll/withdll.cpp
+++ b/samples/withdll/withdll.cpp
@@ -441,7 +441,7 @@ int CDECL main(int argc, char **argv)
 
         HMODULE hDll = LoadLibraryExA(rpszDllsOut[n], NULL, DONT_RESOLVE_DLL_REFERENCES);
         if (hDll == NULL) {
-            printf("withdll.exe: Error: %s failed to load (error %d).\n",
+            printf("withdll.exe: Error: %s failed to load (error %ld).\n",
                    rpszDllsOut[n],
                    GetLastError());
             return 9003;
@@ -504,7 +504,7 @@ int CDECL main(int argc, char **argv)
                                      NULL, NULL, TRUE, dwFlags, NULL, NULL,
                                      &si, &pi, nDlls, rpszDllsOut, NULL)) {
         DWORD dwError = GetLastError();
-        printf("withdll.exe: DetourCreateProcessWithDllEx failed: %d\n", dwError);
+        printf("withdll.exe: DetourCreateProcessWithDllEx failed: %ld\n", dwError);
         if (dwError == ERROR_INVALID_HANDLE) {
 #if DETOURS_64BIT
             printf("withdll.exe: Can't detour a 32-bit target process from a 64-bit parent process.\n");
@@ -525,7 +525,7 @@ int CDECL main(int argc, char **argv)
 
     DWORD dwResult = 0;
     if (!GetExitCodeProcess(pi.hProcess, &dwResult)) {
-        printf("withdll.exe: GetExitCodeProcess failed: %d\n", GetLastError());
+        printf("withdll.exe: GetExitCodeProcess failed: %ld\n", GetLastError());
         return 9010;
     }
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ DETOURS_SOURCE_BROWSING = 0
 
 #######################/#######################################################
 ##
-CFLAGS=/nologo /W4 /WX /Zi /MT /Gy /Gm- /Zl /Od
+CFLAGS=/nologo /W4 /WX /we4777 /Zi /MT /Gy /Gm- /Zl /Od
 
 !IF $(DETOURS_SOURCE_BROWSING)==1
 CFLAGS=$(CFLAGS) /FR


### PR DESCRIPTION
Most of these are using %d for a DWORD when it should be %ld.