### PR TITLE
DetourProcessViaHelperDllsW should not call ResumeThread twice

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -1324,8 +1324,6 @@ BOOL WINAPI DetourProcessViaHelperDllsW(_In_ DWORD dwTargetPid,
         }
 
         ResumeThread(pi.hThread);
-
-        ResumeThread(pi.hThread);
         WaitForSingleObject(pi.hProcess, INFINITE);
 
         DWORD dwResult = 500;


### PR DESCRIPTION
Fixes #97 found by @svark