### PR TITLE
Samples: Fix findfunc + symtest samples using incorrect dll name.

### DIFF
--- a/samples/findfunc/Makefile
+++ b/samples/findfunc/Makefile
@@ -170,6 +170,9 @@ test: all
     @echo -------- Should load extend$(DETOURS_BITS).dll dynamically using withdll.exe -----------
     $(BIND)\withdll.exe -d:$(BIND)\extend$(DETOURS_BITS).dll $(BIND)\findfunc.exe
     @echo.
+    @echo -------- Should list symbols using symtest.exe -----------
+    $(BIND)\symtest.exe
+    @echo.
     @echo -------- Test completed. ------------------------------------------------
 
 ################################################################# End of File.

--- a/samples/findfunc/extend.cpp
+++ b/samples/findfunc/extend.cpp
@@ -24,9 +24,9 @@ static DWORD WINAPI Extend(DWORD dwCount)
 {
     InterlockedIncrement(&nExtends);
 
-    printf("extend.dll: Extend    (%d) -> %d.\n", dwCount, dwCount + 1000);
+    printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Extend    (%d) -> %d.\n", dwCount, dwCount + 1000);
     dwCount = TrueTarget(dwCount + 1000);
-    printf("extend.dll: Extend    (.....) -> %d.\n", dwCount);
+    printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Extend    (.....) -> %d.\n", dwCount);
     return dwCount;
 }
 
@@ -35,9 +35,9 @@ static DWORD WINAPI Intern(DWORD dwCount)
 {
     InterlockedIncrement(&nInterns);
 
-    printf("extend.dll:    Intern (%d) -> %d.\n", dwCount, dwCount + 10);
+    printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:    Intern (%d) -> %d.\n", dwCount, dwCount + 10);
     dwCount = TrueHidden(dwCount + 10);
-    printf("extend.dll:    Intern (.....) -> %d.\n", dwCount);
+    printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll:    Intern (.....) -> %d.\n", dwCount);
     return dwCount;
 }
 
@@ -50,26 +50,26 @@ static int WINAPI ExtendEntryPoint()
     // from the ones that require debug symbols (Hidden).
     TrueTarget =
         (DWORD (WINAPI *)(DWORD))
-        DetourFindFunction("target.dll", "Target");
+        DetourFindFunction("target" DETOURS_STRINGIFY(DETOURS_BITS) ".dll", "Target");
     DetourTransactionBegin();
     DetourUpdateThread(GetCurrentThread());
     DetourAttach(&(PVOID&)TrueTarget, Extend);
     error = DetourTransactionCommit();
 
     if (error == NO_ERROR) {
-        printf("extend.dll: Detoured Target().\n");
+        printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Detoured Target().\n");
     }
     else {
-        printf("extend.dll: Error detouring Target(): %d\n", error);
+        printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Error detouring Target(): %d\n", error);
     }
 
     // Now try to detour the functions requiring debug symbols.
     TrueHidden =
         (DWORD (WINAPI *)(DWORD))
-        DetourFindFunction("target.dll", "Hidden");
+        DetourFindFunction("target" DETOURS_STRINGIFY(DETOURS_BITS) ".dll", "Hidden");
     if (TrueHidden == NULL) {
         error = GetLastError();
-        printf("extend.dll: TrueHidden = %p (error = %d)\n", TrueHidden, error);
+        printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: TrueHidden = %p (error = %d)\n", TrueHidden, error);
     }
 
     DetourTransactionBegin();
@@ -78,14 +78,14 @@ static int WINAPI ExtendEntryPoint()
     error = DetourTransactionCommit();
 
     if (error == NO_ERROR) {
-        printf("extend.dll: Detoured Hidden().\n");
+        printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Detoured Hidden().\n");
     }
     else {
-        printf("extend.dll: Error detouring Hidden(): %d\n", error);
+        printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Error detouring Hidden(): %d\n", error);
     }
 
     // Now let the application start executing.
-    printf("extend.dll: Calling EntryPoint\n");
+    printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Calling EntryPoint\n");
     fflush(stdout);
 
     return TrueEntryPoint();
@@ -104,7 +104,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
     if (dwReason == DLL_PROCESS_ATTACH) {
         DetourRestoreAfterWith();
 
-        printf("extend.dll: Starting.\n");
+        printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Starting.\n");
         fflush(stdout);
 
         // NB: DllMain can't call LoadLibrary, so we hook the app entry point.
@@ -117,10 +117,10 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         error = DetourTransactionCommit();
 
         if (error == NO_ERROR) {
-            printf("extend.dll: Detoured EntryPoint().\n");
+            printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Detoured EntryPoint().\n");
         }
         else {
-            printf("extend.dll: Error detouring EntryPoint(): %d\n", error);
+            printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Error detouring EntryPoint(): %d\n", error);
         }
     }
     else if (dwReason == DLL_PROCESS_DETACH) {
@@ -141,7 +141,7 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD dwReason, LPVOID reserved)
         DetourDetach(&(PVOID&)TrueEntryPoint, ExtendEntryPoint);
         error = DetourTransactionCommit();
 
-        printf("extend.dll: Removed Target() detours (%d), %d/%d calls.\n",
+        printf("extend" DETOURS_STRINGIFY(DETOURS_BITS) ".dll: Removed Target() detours (%d), %d/%d calls.\n",
                error, nExtends, nInterns);
 
         fflush(stdout);

--- a/samples/findfunc/symtest.cpp
+++ b/samples/findfunc/symtest.cpp
@@ -248,7 +248,7 @@ int __cdecl main(void)
 
     /////////////////////////////////////////////// First, try GetProcAddress.
     //
-    PCHAR pszFile = "target.dll";
+    PCHAR pszFile = "target" DETOURS_STRINGIFY(DETOURS_BITS) ".dll";
     HMODULE hModule = LoadLibraryA(pszFile);
     if (hModule == NULL) {
         printf("LoadLibraryA(%s) failed: %d\n", pszFile, GetLastError());


### PR DESCRIPTION
@GladYouLikeIt described the bug in the issue:

> Extend.cpp is built into extend64.dll for x64, and extend86.dll for x86,
> but the code in samples\findfunc\extend.cpp references the dll without
> specifying the DETOURS_BITS in the dll name. DetourFindFunction fails
> at runtime because of this.

@ohuseyinoglu noted the same bug in SymTest.cpp, which caused it to
completely error out. I've added it to nmake test to make sure it continues
to run in the future. 

Fixes #2