### PR TITLE
Merge code from detours 3.0 build 343

### DIFF
--- a/CREDITS.TXT
+++ b/CREDITS.TXT
@@ -3,6 +3,9 @@ The following individuals have helped identify specific bugs and improvements
 in Detours.  The entire Detours community has benefited from their help.
 ==============================================================================
 
+* Jay Krell:          Identified error in DetourFindPayload that caused a
+                      incorrect failure when pcbData is NULL. (Build_342)
+
 * Jay Krell:          Identified issue with VirtualSize == 0 files created in
                       NT 3.1 images. (Build_339)
 

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -803,9 +803,9 @@ PVOID WINAPI DetourFindPayload(_In_opt_ HMODULE hModule,
 
                 if (pcbData) {
                     *pcbData = pSection->cbBytes - sizeof(*pSection);
-                    SetLastError(NO_ERROR);
-                    return (PBYTE)(pSection + 1);
                 }
+                SetLastError(NO_ERROR);
+                return (PBYTE)(pSection + 1);
             }
 
             pbData = (PBYTE)pSection + pSection->cbBytes;


### PR DESCRIPTION
Detours 4.0.1 looks like it's Detours 3.0 build_339 changed its name by comparing the code and looking at git commit logs, so the code in follow version need to be merged.