### PR TITLE
Fix: Delete payload after finish associated task

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -11,7 +11,6 @@
 #define DETOURS_INTERNAL
 #include "detours.h"
 #include <stddef.h>
-#include <assert.h>
 
 #if DETOURS_VERSION != 0x4c0c1   // 0xMAJORcMINORcPATCH
 #error detours.h version mismatch

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -11,6 +11,7 @@
 #define DETOURS_INTERNAL
 #include "detours.h"
 #include <stddef.h>
+#include <assert.h>
 
 #if DETOURS_VERSION != 0x4c0c1   // 0xMAJORcMINORcPATCH
 #error detours.h version mismatch
@@ -1018,6 +1019,18 @@ VOID CALLBACK DetourFinishHelperProcess(_In_ HWND,
         delete[] rlpDlls;
         rlpDlls = NULL;
     }
+
+	//Delete the payload after execution to release the memory occupied by it
+	if (s_pHelper != NULL)
+	{
+		HMODULE hModule = DetourGetContainingModule(s_pHelper);
+		assert(hModule != NULL);
+		if (hModule != NULL)
+		{
+			VirtualFree(hModule, 0, MEM_RELEASE);
+			hModule = NULL;
+		}
+	}
 
     ExitProcess(Result);
 }

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -1019,7 +1019,7 @@ VOID CALLBACK DetourFinishHelperProcess(_In_ HWND,
         rlpDlls = NULL;
     }
 
-    //Delete the payload after execution to release the memory occupied by it
+    // Delete the payload after execution to release the memory occupied by it
     if (s_pHelper != NULL) {
         DetourFreePayload(s_pHelper);
     }

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -1020,8 +1020,7 @@ VOID CALLBACK DetourFinishHelperProcess(_In_ HWND,
     }
 
     //Delete the payload after execution to release the memory occupied by it
-    if (s_pHelper != NULL)
-    {
+    if (s_pHelper != NULL) {
         DetourFreePayload(s_pHelper);
     }
 

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -1023,13 +1023,7 @@ VOID CALLBACK DetourFinishHelperProcess(_In_ HWND,
 	//Delete the payload after execution to release the memory occupied by it
 	if (s_pHelper != NULL)
 	{
-		HMODULE hModule = DetourGetContainingModule(s_pHelper);
-		assert(hModule != NULL);
-		if (hModule != NULL)
-		{
-			VirtualFree(hModule, 0, MEM_RELEASE);
-			hModule = NULL;
-		}
+        DetourFreePayload(s_pHelper);
 	}
 
     ExitProcess(Result);

--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -1020,11 +1020,11 @@ VOID CALLBACK DetourFinishHelperProcess(_In_ HWND,
         rlpDlls = NULL;
     }
 
-	//Delete the payload after execution to release the memory occupied by it
-	if (s_pHelper != NULL)
-	{
+    //Delete the payload after execution to release the memory occupied by it
+    if (s_pHelper != NULL)
+    {
         DetourFreePayload(s_pHelper);
-	}
+    }
 
     ExitProcess(Result);
 }

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -37,7 +37,7 @@ int Detour_AssertExprWithFunctionName(int reportType, const char* filename, int 
     SetLastError(dwLastError);
     return nRet;
 }
-#endif//_DEBUG
+#endif// _DEBUG
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -20,6 +20,27 @@
 
 //////////////////////////////////////////////////////////////////////////////
 //
+
+#ifdef _DEBUG
+extern "C" IMAGE_DOS_HEADER __ImageBase;
+int Detour_AssertExprWithFunctionName(int reportType, const char* filename, int linenumber, const char* FunctionName, const char* msg)
+{
+    int nRet = 0;
+    DWORD dwLastError = GetLastError();
+    CHAR szModuleNameWithFunctionName[MAX_PATH * 2];
+    szModuleNameWithFunctionName[0] = 0;
+    GetModuleFileNameA((HMODULE)&__ImageBase, szModuleNameWithFunctionName, ARRAYSIZE(szModuleNameWithFunctionName));
+    StringCchCatNA(szModuleNameWithFunctionName, ARRAYSIZE(szModuleNameWithFunctionName), ",", ARRAYSIZE(szModuleNameWithFunctionName) - strlen(szModuleNameWithFunctionName) - 1);
+    StringCchCatNA(szModuleNameWithFunctionName, ARRAYSIZE(szModuleNameWithFunctionName), FunctionName, ARRAYSIZE(szModuleNameWithFunctionName) - strlen(szModuleNameWithFunctionName) - 1);
+    SetLastError(dwLastError);
+    nRet = _CrtDbgReport(reportType, filename, linenumber, szModuleNameWithFunctionName, msg);
+    SetLastError(dwLastError);
+    return nRet;
+}
+#endif//_DEBUG
+
+//////////////////////////////////////////////////////////////////////////////
+//
 struct _DETOUR_ALIGN
 {
     BYTE    obTarget        : 3;

--- a/src/detours.h
+++ b/src/detours.h
@@ -921,9 +921,9 @@ int Detour_AssertExprWithFunctionName(int reportType, const char* filename, int 
 
 #define DETOUR_ASSERT(expr) DETOUR_ASSERT_EXPR_WITH_FUNCTION((expr), #expr)
 
-#else//_DEBUG
+#else// _DEBUG
 #define DETOUR_ASSERT(expr)
-#endif//_DEBUG
+#endif// _DEBUG
 
 #ifndef DETOUR_TRACE
 #if DETOUR_DEBUG

--- a/src/detours.h
+++ b/src/detours.h
@@ -47,6 +47,7 @@
 #include <strsafe.h>
 #pragma warning(pop)
 #endif
+#include <crtdbg.h>
 
 // From winerror.h, as this error isn't found in some SDKs:
 //
@@ -908,6 +909,21 @@ PDETOUR_SYM_INFO DetourLoadImageHlp(VOID);
 #error detours.h must be included before stdio.h (or at least define _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS earlier)
 #endif
 #define _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS 1
+
+#ifdef _DEBUG
+
+int Detour_AssertExprWithFunctionName(int reportType, const char* filename, int linenumber, const char* FunctionName, const char* msg);
+
+#define DETOUR_ASSERT_EXPR_WITH_FUNCTION(expr, msg) \
+    (void) ((expr) || \
+    (1 != Detour_AssertExprWithFunctionName(_CRT_ASSERT, __FILE__, __LINE__,__FUNCTION__, msg)) || \
+    (_CrtDbgBreak(), 0))
+
+#define DETOUR_ASSERT(expr) DETOUR_ASSERT_EXPR_WITH_FUNCTION((expr), #expr)
+
+#else//_DEBUG
+#define DETOUR_ASSERT(expr)
+#endif//_DEBUG
 
 #ifndef DETOUR_TRACE
 #if DETOUR_DEBUG

--- a/src/detours.h
+++ b/src/detours.h
@@ -615,6 +615,7 @@ PVOID WINAPI DetourFindPayloadEx(_In_ REFGUID rguid,
 
 DWORD WINAPI DetourGetSizeOfPayloads(_In_opt_ HMODULE hModule);
 
+BOOL WINAPI DetourFreePayload(_In_ PVOID pvData);
 ///////////////////////////////////////////////// Persistent Binary Functions.
 //
 

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -24,8 +24,8 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 const GUID DETOUR_EXE_RESTORE_GUID = {
-	0xbda26f34, 0xbc82, 0x4829,
-	{ 0x9e, 0x64, 0x74, 0x2c, 0x4, 0xc8, 0x4f, 0xa0 } };
+    0xbda26f34, 0xbc82, 0x4829,
+    { 0x9e, 0x64, 0x74, 0x2c, 0x4, 0xc8, 0x4f, 0xa0 } };
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -841,21 +841,21 @@ PVOID WINAPI DetourFindPayloadEx(_In_ REFGUID rguid,
 
 BOOL WINAPI DetourFreePayload(_In_ PVOID pvData)
 {
-	BOOL fSucceeded = FALSE;
+    BOOL fSucceeded = FALSE;
 
-	HMODULE hModule = DetourGetContainingModule(pvData);
-	assert(hModule != NULL);
-	if (hModule != NULL)
-	{
-		fSucceeded = VirtualFree(hModule, 0, MEM_RELEASE);
-		assert(fSucceeded);
-		if (fSucceeded)
-		{
-			hModule = NULL;
-		}
-	}
+    HMODULE hModule = DetourGetContainingModule(pvData);
+    assert(hModule != NULL);
+    if (hModule != NULL)
+    {
+        fSucceeded = VirtualFree(hModule, 0, MEM_RELEASE);
+        assert(fSucceeded);
+        if (fSucceeded)
+        {
+            hModule = NULL;
+        }
+    }
 
-	return fSucceeded;
+    return fSucceeded;
 }
 
 BOOL WINAPI DetourRestoreAfterWithEx(_In_reads_bytes_(cbData) PVOID pvData,
@@ -904,11 +904,11 @@ BOOL WINAPI DetourRestoreAfterWithEx(_In_reads_bytes_(cbData) PVOID pvData,
         }
         VirtualProtect(pder->pidh, pder->cbidh, dwPermIdh, &dwIgnore);
     }
-	//Delete the payload after successful recovery to prevent repeated restore
-	if (fSucceeded)
-	{
+    //Delete the payload after successful recovery to prevent repeated restore
+    if (fSucceeded)
+    {
         DetourFreePayload(pder);
-	}
+    }
     return fSucceeded;
 }
 

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -844,12 +844,10 @@ BOOL WINAPI DetourFreePayload(_In_ PVOID pvData)
 
     HMODULE hModule = DetourGetContainingModule(pvData);
     DETOUR_ASSERT(hModule != NULL);
-    if (hModule != NULL)
-    {
+    if (hModule != NULL) {
         fSucceeded = VirtualFree(hModule, 0, MEM_RELEASE);
         DETOUR_ASSERT(fSucceeded);
-        if (fSucceeded)
-        {
+        if (fSucceeded) {
             hModule = NULL;
         }
     }
@@ -904,8 +902,7 @@ BOOL WINAPI DetourRestoreAfterWithEx(_In_reads_bytes_(cbData) PVOID pvData,
         VirtualProtect(pder->pidh, pder->cbidh, dwPermIdh, &dwIgnore);
     }
     //Delete the payload after successful recovery to prevent repeated restore
-    if (fSucceeded)
-    {
+    if (fSucceeded) {
         DetourFreePayload(pder);
     }
     return fSucceeded;

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -842,6 +842,7 @@ BOOL WINAPI DetourFreePayload(_In_ PVOID pvData)
 {
     BOOL fSucceeded = FALSE;
 
+    // If you have any doubts about the following code, please refer to the comments in DetourCopyPayloadToProcess.
     HMODULE hModule = DetourGetContainingModule(pvData);
     DETOUR_ASSERT(hModule != NULL);
     if (hModule != NULL) {
@@ -904,6 +905,7 @@ BOOL WINAPI DetourRestoreAfterWithEx(_In_reads_bytes_(cbData) PVOID pvData,
     // Delete the payload after successful recovery to prevent repeated restore
     if (fSucceeded) {
         DetourFreePayload(pder);
+        pder = NULL;
     }
     return fSucceeded;
 }

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -12,6 +12,7 @@
 // #define DETOUR_DEBUG 1
 #define DETOURS_INTERNAL
 #include "detours.h"
+#include <assert.h>
 
 #if DETOURS_VERSION != 0x4c0c1   // 0xMAJORcMINORcPATCH
 #error detours.h version mismatch
@@ -23,8 +24,8 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 const GUID DETOUR_EXE_RESTORE_GUID = {
-    0x2ed7a3ff, 0x3339, 0x4a8d,
-    { 0x80, 0x5c, 0xd4, 0x98, 0x15, 0x3f, 0xc2, 0x8f }};
+	0xbda26f34, 0xbc82, 0x4829,
+	{ 0x9e, 0x64, 0x74, 0x2c, 0x4, 0xc8, 0x4f, 0xa0 } };
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -884,6 +885,17 @@ BOOL WINAPI DetourRestoreAfterWithEx(_In_reads_bytes_(cbData) PVOID pvData,
         }
         VirtualProtect(pder->pidh, pder->cbidh, dwPermIdh, &dwIgnore);
     }
+	//Delete the payload after successful recovery to prevent repeated recovery
+	if (fSucceeded)
+	{
+		HMODULE hModule = DetourGetContainingModule(pder);
+		assert(hModule != NULL);
+		if (hModule != NULL)
+		{
+			VirtualFree(hModule, 0, MEM_RELEASE);
+			hModule = NULL;
+		}
+	}
     return fSucceeded;
 }
 

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -901,7 +901,7 @@ BOOL WINAPI DetourRestoreAfterWithEx(_In_reads_bytes_(cbData) PVOID pvData,
         }
         VirtualProtect(pder->pidh, pder->cbidh, dwPermIdh, &dwIgnore);
     }
-    //Delete the payload after successful recovery to prevent repeated restore
+    // Delete the payload after successful recovery to prevent repeated restore
     if (fSucceeded) {
         DetourFreePayload(pder);
     }

--- a/src/modules.cpp
+++ b/src/modules.cpp
@@ -12,7 +12,6 @@
 // #define DETOUR_DEBUG 1
 #define DETOURS_INTERNAL
 #include "detours.h"
-#include <assert.h>
 
 #if DETOURS_VERSION != 0x4c0c1   // 0xMAJORcMINORcPATCH
 #error detours.h version mismatch
@@ -844,11 +843,11 @@ BOOL WINAPI DetourFreePayload(_In_ PVOID pvData)
     BOOL fSucceeded = FALSE;
 
     HMODULE hModule = DetourGetContainingModule(pvData);
-    assert(hModule != NULL);
+    DETOUR_ASSERT(hModule != NULL);
     if (hModule != NULL)
     {
         fSucceeded = VirtualFree(hModule, 0, MEM_RELEASE);
-        assert(fSucceeded);
+        DETOUR_ASSERT(fSucceeded);
         if (fSucceeded)
         {
             hModule = NULL;


### PR DESCRIPTION
Delete the payload after finish associated task, and need change the DETOUR_EXE_RESTORE_GUID's value for compatible with these dlls that compiled by old version Detours

for example,  create a pair of dlls named dll_createwith_mysocks_32/64.dll, their function is hooked CreateProcess to create any new process with it. 
a 32bit exe(named exe_socks) use dll_createwith_mysocks_32.dll by PE import table. so it start any process will with dll_createwith_mysocks_32/64.dll.
now it start a 32bit exe (named exe_vs), but exe_vs will load a dll (named dll_createwith_myluainject_32/64.dll) that build with detours and their function is hooked CreateProcess to create any new process with it.
so if  exe_vs start a 64bit exe, DetourCreateProcessXXX api will only restore the first IAT which modifed by dll_createwith_mysocks_32/64.dll, and dll_createwith_myluainject_32/64.dll modified IAT will not restore. because they create payload with the same GUID  DETOUR_EXE_RESTORE_GUID.  and Detour will do restore with the first founded payload twice.
so make dll_createwith_mysocks_32/64.dll can not work ok.
so we need delete the payload after the associated task finish immediately. if do like this, the payload with GUID  DETOUR_EXE_RESTORE_GUID can be used by the next dll that complied by Detours.

And for compatible with these dlls that compiled by old version Detours which we don`t have source code to recompile these.
so we need change  DETOUR_EXE_RESTORE_GUID's value to a new value, so even these dlls can not delete the payload, because we only search the new DETOUR_EXE_RESTORE_GUID's value's payload. so the old playload things will not executed by us.
