### PR TITLE
Fixed#116 via changing to signed for negative diff

### DIFF
--- a/samples/syelog/syelogd.cpp
+++ b/samples/syelog/syelogd.cpp
@@ -93,7 +93,7 @@ static PCSTR FileTimeToString(PCHAR pszBuffer, DWORD cbBuffer, FILETIME ftTime)
         ul.LowPart = ftTime.dwLowDateTime;
         ul.HighPart = ftTime.dwHighDateTime;
 
-        ULONG64 delta = ul.QuadPart - s_llLastTime;
+        LONG64 delta = ul.QuadPart - s_llLastTime;
         s_llLastTime = ul.QuadPart;
         delta /= 10000;
 


### PR DESCRIPTION
Addressed : Issue #116 [syelogd] Negative timing difference between successive events with option /d (delta time).

Please can you review and merge the fix.

Thanks 👍 