### PR TITLE
CI: Fix action workflow to use latests msvc cmd version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Setup build environment variables using vcvarsall.bat.
       - name: Configure MSCV Compiler for ${{ matrix.arch }}
-        uses: ilammy/msvc-dev-cmd@v1.3.0
+        uses: ilammy/msvc-dev-cmd@v1.4.1
         with:
           arch: ${{ matrix.arch }}
 


### PR DESCRIPTION
Detours CI was broken by a deprecation in the github actions API.
We need to bump to the latest version of msvc action to get the fix. 