### PR TITLE
Maintenance: Remove unused variables found static analysis

### DIFF
--- a/samples/cping/cping.cpp
+++ b/samples/cping/cping.cpp
@@ -185,7 +185,6 @@ NTSTATUS (NTAPI *Real_NtDeviceIoControlFile)(HANDLE FileHandle,
 //////////////////////////////////////////////////////////////////////////////
 //
 static LONG     s_nInCall = 0;
-static LONG     s_nInIRpc = 0;
 static ULONG    s_nThread = 0;
 
 enum {

--- a/samples/dumpi/dumpi.cpp
+++ b/samples/dumpi/dumpi.cpp
@@ -31,10 +31,6 @@ do { if (!(x)) { AssertMessage(#x, __FILE__, __LINE__); DebugBreak(); }} while (
 
 //////////////////////////////////////////////////////////////////////////////
 //
-static BOOL s_fSubs = FALSE;
-
-//////////////////////////////////////////////////////////////////////////////
-//
 static CHAR s_szFile[MAX_PATH] = "\0";
 
 static BOOL CALLBACK ListFileCallback(_In_opt_ PVOID pContext,

--- a/samples/region/region.cpp
+++ b/samples/region/region.cpp
@@ -13,7 +13,6 @@
 
 //////////////////////////////////////////////////////////////////////////////
 //
-static LONG dwSlept = 0;
 static DWORD (WINAPI * TrueSleepEx)(DWORD dwMilliseconds, BOOL bAlertable) = SleepEx;
 
 DWORD WINAPI LoudSleepEx(DWORD dwMilliseconds, BOOL bAlertable)

--- a/samples/tracebld/trcbld.cpp
+++ b/samples/tracebld/trcbld.cpp
@@ -59,10 +59,6 @@ static TBLOG_PAYLOAD s_ChildPayload;
 static CRITICAL_SECTION s_csChildPayload;
 static DWORD s_nTraceProcessId = 0;
 static LONG s_nChildCnt = 0;
-static PWCHAR s_pwEnvironment = NULL;
-static DWORD s_cwEnvironment = NULL;
-static PCHAR s_pbEnvironment = NULL;
-static DWORD s_cbEnvironment = NULL;
 
 static CRITICAL_SECTION s_csPipe;                       // Guards access to hPipe.
 static HANDLE           s_hPipe = INVALID_HANDLE_VALUE;

--- a/samples/withdll/withdll.cpp
+++ b/samples/withdll/withdll.cpp
@@ -155,8 +155,6 @@ void ProtectToString(DWORD Protect, char *pszBuffer, size_t cBuffer)
     }
 }
 
-static BYTE buffer[65536];
-
 typedef union
 {
     struct


### PR DESCRIPTION
- CodeQL found these unused variables, remove them.