### PR TITLE
CI: `git checkout HEAD^2` step is no longer necessary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,18 +26,6 @@ jobs:
     steps:
       - name: Clone Repository
         uses: actions/checkout@v2
-        with:
-          # Must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head of the pull request.
-          # Only include this option if you are running this workflow on pull requests.
-          fetch-depth: 2
-
-      # If this run was triggered by a pull request event then checkout
-      # the head of the pull request instead of the merge commit.
-      # Only include this step if you are running this workflow on pull requests.
-      - name: Checkout head of the pull request
-        run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
 
       # Setup build environment variables using vcvarsall.bat.
       - name: Configure MSCV Compiler for ${{ matrix.arch }}


### PR DESCRIPTION
The CI builds now report this warning:

```
1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary.
Please remove this step as Code Scanning recommends analyzing the merge commit for best results
```

This step was recommended but is now unnecessary.