### PR TITLE
CI: Follow major version of ilammy/msvc-dev-cmd to get latest fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       # Setup build environment variables using vcvarsall.bat.
       - name: Configure MSCV Compiler for ${{ matrix.arch }}
-        uses: ilammy/msvc-dev-cmd@v1.4.1
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}
 


### PR DESCRIPTION
The @v1 tag is maintained with latest changes automatically. Use this
tag instead of having to manually update on every minor version.