### PR TITLE
Maintenance: Clean up some compiler warnings

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -621,7 +621,7 @@ BOOL WINAPI DetourUpdateProcessWithDllEx(_In_ HANDLE hProcess,
 
     IMAGE_NT_HEADERS32 inh;
 
-    if (hModule == NULL || LoadNtHeaderFromProcess(hProcess, hModule, &inh) == NULL) {
+    if (hModule == NULL || !LoadNtHeaderFromProcess(hProcess, hModule, &inh)) {
         SetLastError(ERROR_INVALID_OPERATION);
         return FALSE;
     }

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -106,7 +106,7 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
         }
     }
 
-    if (inh.IMPORT_DIRECTORY.VirtualAddress != NULL && inh.IMPORT_DIRECTORY.Size == 0) {
+    if (inh.IMPORT_DIRECTORY.VirtualAddress == 0 && inh.IMPORT_DIRECTORY.Size == 0) {
 
         // Don't worry about changing the PE file, 
         // because the load information of the original PE header has been saved and will be restored. 


### PR DESCRIPTION
Spotted with MinGW32 g++

* `uimports.cpp`: `IMAGE_DATA_DIRECTORY.VirtualAddress` is a `DWORD`
  type, not a pointer type, so compare against a scalar type.
* `creatwth.cpp`: `LoadNtHeaderFromProcess` returns a `BOOL`, so compare
  with falsey check.

```sh
i686-w64-mingw32-g++ -c -Wall -Wextra -Wpedantic ./creatwth.cpp

# In file included from ./creatwth.cpp:329:
# ./uimports.cpp: In function 'BOOL UpdateImports32(HANDLE, HMODULE, const CHAR**, DWORD)':
# ./uimports.cpp:109:48: warning: NULL used in arithmetic [-Wpointer-arith]
#   109 |     if (inh.IMPORT_DIRECTORY.VirtualAddress != NULL && inh.IMPORT_DIRECTORY.Size == 0) {
#       |                                                ^~~~
# ./creatwth.cpp: In function 'BOOL DetourUpdateProcessWithDllEx(HANDLE, HMODULE, BOOL, const CHAR**, DWORD)':
# ./creatwth.cpp:624:80: warning: NULL used in arithmetic [-Wpointer-arith]
#   624 |     if (hModule == NULL || LoadNtHeaderFromProcess(hProcess, hModule, &inh) == NULL) {
#       |                                                                                ^~~~
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/Detours/pull/166)