### PR TITLE
Minor fixes in symtest example

### DIFF
--- a/samples/findfunc/symtest.cpp
+++ b/samples/findfunc/symtest.cpp
@@ -283,7 +283,7 @@ int __cdecl main(void)
 
     IMAGEHLP_MODULE64 modinfo;
     ZeroMemory(&modinfo, sizeof(modinfo));
-    modinfo.SizeOfStruct = 512/*sizeof(modinfo)*/;
+    modinfo.SizeOfStruct = sizeof(modinfo);
     if (!pfSymGetModuleInfo64(hProcess, (DWORD64)hModule, &modinfo)) {
         printf("SymGetModuleInfo64(%p, %p) [64] failed: %ld\n",
                       hProcess, hModule, GetLastError());
@@ -318,7 +318,7 @@ int __cdecl main(void)
         printf("===Enum===\n");
         SetLastError(0);
         nSymbolCount = 0;
-        if (!pfSymEnumSymbols(hProcess, (DWORD64)hModule, NULL, SymEnumerateSymbols, NULL)) {
+        if (!pfSymEnumSymbols(hProcess, loaded, NULL, SymEnumerateSymbols, NULL)) {
             printf("SymEnumSymbols() failed: %ld\n",
                           GetLastError());
         }


### PR DESCRIPTION
Fixed invocations of `SymGetModuleInfo64` and `SymEnumSymbols`
Tested on x64 only.

Output snippets from `symtest.exe` before fix:

    SymGetModuleInfo64(FFFFFFFFFFFFFFFF, 000000006EBC0000) [64] failed: 87

and

    ===Enum===
    SymEnumSymbols() failed: 318

Output snippets from `symtest.exe` after fix:

    SymGetModuleInfo64(FFFFFFFFFFFFFFFF, 000000006EBC0000) [64] succeeded: 0
    NumSyms:         0
    SymType:         3
    ModuleName:      target64
    ImageName:       target64.dll
    LoadedImageName: target64.dll

and

    ===Enum===
      000000006EBD4A60: __newclmap
      000000006EBD4A60: __newclmap
      000000006EBD2238: __guard_xfg_dispatch_icall_fptr
      000000006EBDDA40: _fltused
      000000006EBD8AC0: __mask_mant
      000000006EBDD000: SelfHidden
      000000006EBC1000: Target
      000000006EBC1060: Hidden


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/167)