### PR TITLE
Maintenance: Revert boolean flip

### DIFF
--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -106,7 +106,7 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
         }
     }
 
-    if (inh.IMPORT_DIRECTORY.VirtualAddress == 0 && inh.IMPORT_DIRECTORY.Size == 0) {
+    if (inh.IMPORT_DIRECTORY.VirtualAddress != 0 && inh.IMPORT_DIRECTORY.Size == 0) {
 
         // Don't worry about changing the PE file, 
         // because the load information of the original PE header has been saved and will be restored. 


### PR DESCRIPTION
Commit 99ac5f91622c7a95e99c85fb9d7141e6c4d16244 ("Maintenance: Clean up some compiler warnings") flipped a boolean check. Revert.

Reported-by: @sonyps5201314 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/168)