### PR TITLE
Prevent conflict with MINGW32 defines

### DIFF
--- a/src/detours.h
+++ b/src/detours.h
@@ -126,7 +126,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //
 
-#if (_MSC_VER < 1299)
+#if (_MSC_VER < 1299) && !defined(__MINGW32__)
 typedef LONG LONG_PTR;
 typedef ULONG ULONG_PTR;
 #endif


### PR DESCRIPTION
mingw defines (typedefs?) `ULONG_PTR` and `LONG_PTR`, but not `_MSC_VER`. So the `typedef LONG LONG_PTR` in `detours.h` gives an error when compiling with mingw.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/173)