### PR TITLE
CI: Only run CodeQL for Debug matrix configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Initialize CodeQL for C++
         uses: github/codeql-action/init@v1
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2019' && matrix.conf == 'Debug' }}
         with:
           languages: cpp
           config-file: ./.github/codeql/codeql-config.yml
@@ -66,4 +66,4 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-2019' && matrix.conf == 'Debug' }}


### PR DESCRIPTION
The new "Debug" build now compiles all code.
So there's no use in running static analysis on Release.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/179)