### PR TITLE
Fix potential integer overflow

### DIFF
--- a/src/detours.h
+++ b/src/detours.h
@@ -36,6 +36,7 @@
 #pragma warning(disable:6102 6103) // /analyze warnings
 #endif
 #include <strsafe.h>
+#include <intsafe.h>
 #pragma warning(pop)
 #endif
 

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -167,14 +167,14 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
     }
     DWORD obDll;
     if (DWordAdd(obTab, stSize, &obDll) != S_OK) {
-        DETOUR_TRACE("Import table size overflow\n");
+        DETOUR_TRACE(("Import table size overflow\n"));
         goto finish;
     }
     DWORD obStr = obDll;
     cbNew = obStr;
     for (n = 0; n < nDlls; n++) {
         if (DWordAdd(cbNew, PadToDword((DWORD)strlen(plpDlls[n]) + 1), &cbNew) != S_OK) {
-            DETOUR_TRACE("Overflow adding string table entry\n");
+            DETOUR_TRACE(("Overflow adding string table entry\n"));
             goto finish;
         }
     }

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -146,23 +146,23 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
     DWORD nOldDlls = inh.IMPORT_DIRECTORY.Size / sizeof(IMAGE_IMPORT_DESCRIPTOR);
     DWORD obRem;
     if (DWordMult(sizeof(IMAGE_IMPORT_DESCRIPTOR), nDlls, &obRem) != S_OK) {
-        DETOUR_TRACE("too many new DLLs.\n");
+        DETOUR_TRACE(("too many new DLLs.\n"));
         goto finish;
     }
     DWORD obOld;
     if (DWordAdd(obRem, sizeof(IMAGE_IMPORT_DESCRIPTOR) * nOldDlls, &obOld) != S_OK) {
-        DETOUR_TRACE("DLL entries overflow.\n");
+        DETOUR_TRACE(("DLL entries overflow.\n"));
         goto finish;
     }
     DWORD obTab = PadToDwordPtr(obOld);
     // Check for integer overflow.
     if (obTab < obOld) {
-        DETOUR_TRACE("DLL entries padding overflow.\n");
+        DETOUR_TRACE(("DLL entries padding overflow.\n"));
         goto finish;
     }
     DWORD stSize;
     if (DWordMult(sizeof(DWORD_XX) * 4, nDlls, &stSize) != S_OK) {
-        DETOUR_TRACE("String table overflow.\n");
+        DETOUR_TRACE(("String table overflow.\n"));
         goto finish;
     }
     DWORD obDll;


### PR DESCRIPTION
When injecting a DLL into a process, it is possible that the process memory  has been corrupted.  The values in the import table for the process could be incorrect, which could cause an integer overflow when calculating the size of the new import table.  Add code to protect against this to UPDATE_IMPORTS_XX.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/182)