### PR TITLE
Maintenance: Fix incorrect use of NULL to initialize DWORD

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -191,7 +191,7 @@ static PVOID FindPayloadInRemoteDetourSection(_In_ HANDLE hProcess,
                                                _In_ PVOID pvRemoteDetoursSection)
 {
     if (pcbData) {
-        *pcbData = NULL;
+        *pcbData = 0;
     }
 
     PBYTE pbData = (PBYTE)pvRemoteDetoursSection;


### PR DESCRIPTION
Fixes #186, found by compiling with `-Wconversion-null`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/187)