### PR TITLE
Fix Compiler Warnings

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -1436,7 +1436,7 @@ BOOL WINAPI DetourProcessViaHelperDllsW(_In_ DWORD dwTargetPid,
     PDETOUR_EXE_HELPER helper = NULL;
     HRESULT hr;
     WCHAR szDllName[MAX_PATH];
-    int cchWrittenWideChar;
+    unsigned int cchWrittenWideChar;
     DWORD nLen = GetEnvironmentVariableW(L"WINDIR", szExe, ARRAYSIZE(szExe));
 
     DETOUR_TRACE(("DetourProcessViaHelperDlls(pid=%lu,dlls=%lu)\n", dwTargetPid, nDlls));

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1466,7 +1466,7 @@ static BOOL detour_is_region_empty(PDETOUR_REGION pRegion)
 
     // Stop if any of the trampolines aren't free.
     PDETOUR_TRAMPOLINE pTrampoline = ((PDETOUR_TRAMPOLINE)pRegion) + 1;
-    for (int i = 0; i < DETOUR_TRAMPOLINES_PER_REGION; i++) {
+    for (ULONG i = 0; i < DETOUR_TRAMPOLINES_PER_REGION; i++) {
         if (pTrampoline[i].pbRemain != NULL &&
             (pTrampoline[i].pbRemain < pbRegionBeg ||
              pTrampoline[i].pbRemain >= pbRegionLim)) {
@@ -1637,7 +1637,7 @@ LONG WINAPI DetourTransactionCommit()
 
 static BYTE detour_align_from_trampoline(PDETOUR_TRAMPOLINE pTrampoline, BYTE obTrampoline)
 {
-    for (LONG n = 0; n < ARRAYSIZE(pTrampoline->rAlign); n++) {
+    for (ULONG n = 0; n < ARRAYSIZE(pTrampoline->rAlign); n++) {
         if (pTrampoline->rAlign[n].obTrampoline == obTrampoline) {
             return pTrampoline->rAlign[n].obTarget;
         }
@@ -1647,7 +1647,7 @@ static BYTE detour_align_from_trampoline(PDETOUR_TRAMPOLINE pTrampoline, BYTE ob
 
 static LONG detour_align_from_target(PDETOUR_TRAMPOLINE pTrampoline, LONG obTarget)
 {
-    for (LONG n = 0; n < ARRAYSIZE(pTrampoline->rAlign); n++) {
+    for (ULONG n = 0; n < ARRAYSIZE(pTrampoline->rAlign); n++) {
         if (pTrampoline->rAlign[n].obTarget == obTarget) {
             return pTrampoline->rAlign[n].obTrampoline;
         }
@@ -2425,7 +2425,7 @@ LONG WINAPI DetourDetach(_Inout_ PVOID *ppPointer,
     //
     LONG cbTarget = pTrampoline->cbRestore;
     PBYTE pbTarget = pTrampoline->pbRemain - cbTarget;
-    if (cbTarget == 0 || cbTarget > sizeof(pTrampoline->rbCode)) {
+    if (cbTarget == 0 || pTrampoline->cbRestore > sizeof(pTrampoline->rbCode)) {
         error = ERROR_INVALID_BLOCK;
         if (s_fIgnoreTooSmall) {
             goto stop;

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -295,10 +295,10 @@ class CDetourDis
     BOOL                m_bOperandOverride;
     BOOL                m_bAddressOverride;
     BOOL                m_bRaxOverride; // AMD64 only
-    BOOL                m_bVex;
-    BOOL                m_bEvex;
     BOOL                m_bF2;
     BOOL                m_bF3; // x86 only
+    BOOL                m_bVex;
+    BOOL                m_bEvex;
     BYTE                m_nSegmentOverride;
 
     PBYTE *             m_ppbTarget;


### PR DESCRIPTION
`MultiByteToWideChar` never returns negative so it can be safely casted to an unsigned value

Closes #188 and #189

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/192)