### PR TITLE
DetourAttachEx: set out params to NULL on failure

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -2098,6 +2098,12 @@ LONG WINAPI DetourAttachEx(_Inout_ PVOID *ppPointer,
             delete o;
             o = NULL;
         }
+        if (ppRealDetour != NULL) {
+            *ppRealDetour = NULL;
+        }
+        if (ppRealTarget != NULL) {
+            *ppRealTarget = NULL;
+        }
         s_ppPendingError = ppPointer;
         return error;
     }


### PR DESCRIPTION
Sets ppRealDetour and ppRealTarget out params to NULL on failure.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/211)