### PR TITLE
include intsafe.h when compiling with MingW

### DIFF
--- a/src/detours.h
+++ b/src/detours.h
@@ -56,6 +56,7 @@
 #define __try
 #define __except(x) if (0)
 #include <strsafe.h>
+#include <intsafe.h>
 #endif
 
 // From winerror.h, as this error isn't found in some SDKs:


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/223)