### PR TITLE
Tests: Fix flaky module test, which assumed it would be loaded first

### DIFF
--- a/tests/test_module_api.cpp
+++ b/tests/test_module_api.cpp
@@ -241,7 +241,7 @@ TEST_CASE("DetourEnumerateModules", "[module]")
         auto mod = DetourEnumerateModules(nullptr);
 
         REQUIRE( GetLastError() == NO_ERROR );
-        REQUIRE( mod == reinterpret_cast<HMODULE>(&__ImageBase) );
+        REQUIRE( mod != NULL );
     }
 
     SECTION("Passing stack, results in module")


### PR DESCRIPTION
In the case of ASLR this is not always true, so we should not take a
dependency on this behavior.

Reported-by: John McPherson <johnmcp@microsoft.com>

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/227)