### PR TITLE
CI: Switch build matrix off of windows-2016, and on to windows-2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2016]
+        os: [windows-2019, windows-2022]
         arch: [x86, x64, x64_arm, x64_arm64]
         conf: [Release, Debug]
 
@@ -41,21 +41,21 @@ jobs:
           languages: cpp
           config-file: ./.github/codeql/codeql-config.yml
 
-      - name: Build Detours for ${{ matrix.arch }} on ${{ matrix.os }} 
+      - name: Build Detours for ${{ matrix.arch }} on ${{ matrix.os }}
         env:
           # Tell detours what process to target
           DETOURS_TARGET_PROCESSOR: ${{ env.VSCMD_ARG_TGT_ARCH }}
           DETOURS_CONFIG: ${{ matrix.conf }}
         run: nmake
 
-      - name: Run unit tests for ${{ matrix.arch }} on ${{ matrix.os }} 
+      - name: Run unit tests for ${{ matrix.arch }} on ${{ matrix.os }}
         id: run-unit-tests
         env:
           DETOURS_CONFIG: ${{ matrix.conf }}
         run: cd tests && nmake test
         if: ${{ matrix.arch == 'x86' || matrix.arch == 'x64' }}
 
-      - name: Upload artifacts for ${{ matrix.arch }} on ${{ matrix.os }} 
+      - name: Upload artifacts for ${{ matrix.arch }} on ${{ matrix.os }}
         uses: actions/upload-artifact@v2
         with:
           name: artifacts-${{ matrix.os }}

--- a/src/detours.h
+++ b/src/detours.h
@@ -952,10 +952,10 @@ typedef DWORD (NTAPI *PF_SymSetOptions)(_In_ DWORD SymOptions);
 typedef DWORD (NTAPI *PF_SymGetOptions)(VOID);
 typedef DWORD64 (NTAPI *PF_SymLoadModule64)(_In_ HANDLE hProcess,
                                             _In_opt_ HANDLE hFile,
-                                            _In_ LPSTR ImageName,
+                                            _In_opt_ LPSTR ImageName,
                                             _In_opt_ LPSTR ModuleName,
                                             _In_ DWORD64 BaseOfDll,
-                                            _In_opt_ DWORD SizeOfDll);
+                                            _In_ DWORD SizeOfDll);
 typedef BOOL (NTAPI *PF_SymGetModuleInfo64)(_In_ HANDLE hProcess,
                                             _In_ DWORD64 qwAddr,
                                             _Out_ PIMAGEHLP_MODULE64 ModuleInfo);


### PR DESCRIPTION
The github windows-2016 runner is being deprecated in the middle of
March. So lets pre-emptively move off of that and on to the next version
of the runner so we are still testing all the versions of windows we
have available.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/228)