### PR TITLE
Reduce memory fragmentation in x86

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1265,7 +1265,14 @@ static PVOID detour_alloc_region_from_lo(PBYTE pbLo, PBYTE pbHi)
                       mbi.State));
 
         if (mbi.State == MEM_FREE && mbi.RegionSize >= DETOUR_REGION_SIZE) {
-
+#ifdef DETOURS_X86
+            // Reduce memory fragmentation by allocating the end of the region
+            pbTry += mbi.RegionSize;        // Advance pbTry to the end of the free block.
+            if (pbTry > pbHi) {
+                pbTry = pbHi;
+            }
+            pbTry -= DETOUR_REGION_SIZE;    // Move pbTry backwards to ensure that the free block is large enough to hold a trampoline region.
+#endif
             PVOID pv = VirtualAlloc(pbTry,
                                     DETOUR_REGION_SIZE,
                                     MEM_COMMIT|MEM_RESERVE,
@@ -1315,7 +1322,14 @@ static PVOID detour_alloc_region_from_hi(PBYTE pbLo, PBYTE pbHi)
                       mbi.State));
 
         if (mbi.State == MEM_FREE && mbi.RegionSize >= DETOUR_REGION_SIZE) {
-
+#ifdef DETOURS_X86
+            // Reduce memory fragmentation by allocating the end of the region
+            pbTry += mbi.RegionSize;        // Advance pbTry to the end of the free block.
+            if (pbTry > pbHi) {
+                pbTry = pbHi;
+            }
+            pbTry -= DETOUR_REGION_SIZE;    // Move pbTry backwards to ensure that the free block is large enough to hold a trampoline region.
+#endif
             PVOID pv = VirtualAlloc(pbTry,
                                     DETOUR_REGION_SIZE,
                                     MEM_COMMIT|MEM_RESERVE,


### PR DESCRIPTION
The method used to allocate trampolines in Detours does not avoid memory fragmentation, which is especially important on platforms where the virtual address space is scarce (like x86).

In this patch we try to minimize the effects of fragmentation by modifying the requested allocation address so that it will be adjacent to the next occupied memory block.

Without this patch, there is a slight chance that in the course of allocating a new trampoline, Detours will undeliberately split a large contiguous memory block into two smaller blocks, thus causing fragmentation.

The effects of fragmentation can be disastrous, since some applications tend to allocate large quantities of memory as part of their start-up code. In case a single block large enough to fulfill the allocation request cannot be found, these applications
will simply fail to start.