### PR TITLE
fix build error for error C2065: 'GetThreadLocale'

### DIFF
--- a/samples/traceapi/trcapi.cpp
+++ b/samples/traceapi/trcapi.cpp
@@ -7,7 +7,7 @@
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
 #undef WIN32_LEAN_AND_MEAN
-#define _WIN32_WINNT        0x400
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 #define _WINSOCK_DEPRECATED_NO_WARNINGS

--- a/samples/tracebld/trcbld.cpp
+++ b/samples/tracebld/trcbld.cpp
@@ -7,7 +7,7 @@
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
 
-#define _WIN32_WINNT        0x0500
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 

--- a/samples/tracelnk/trclnk.cpp
+++ b/samples/tracelnk/trclnk.cpp
@@ -6,7 +6,7 @@
 //
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
-#define _WIN32_WINNT        0x0400
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 

--- a/samples/tracemem/trcmem.cpp
+++ b/samples/tracemem/trcmem.cpp
@@ -6,7 +6,7 @@
 //
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
-#define _WIN32_WINNT        0x0400
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 

--- a/samples/tracereg/trcreg.cpp
+++ b/samples/tracereg/trcreg.cpp
@@ -6,7 +6,7 @@
 //
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
-#define _WIN32_WINNT        0x0400
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 

--- a/samples/traceser/trcser.cpp
+++ b/samples/traceser/trcser.cpp
@@ -6,7 +6,7 @@
 //
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
-#define _WIN32_WINNT        0x0400
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 

--- a/samples/tracessl/trcssl.cpp
+++ b/samples/tracessl/trcssl.cpp
@@ -6,7 +6,7 @@
 //
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
-#define _WIN32_WINNT        0x0400
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 #define SECURITY_WIN32

--- a/samples/tracetcp/trctcp.cpp
+++ b/samples/tracetcp/trctcp.cpp
@@ -6,7 +6,7 @@
 //
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //
-#define _WIN32_WINNT        0x0400
+#define _WIN32_WINNT        0x0501
 #define WIN32
 #define NT
 #define _WINSOCK_DEPRECATED_NO_WARNINGS


### PR DESCRIPTION
When I try to build sample in vcpkg's download detours code(v4.0.1-2f7d798f9a) , I meet same `build error: C2065: 'GetThreadLocale'` as #202  and #240 , although there is [fix](https://github.com/microsoft/Detours/commit/c89449a12470e7efe0518d8af062c934f636f1b9#diff-446d52d5e28f864320cf9ebb7acdc538566de36a09cab28050c834ea0eb09273R4322) by add `#if(WINVER >= 0x0500)`, but I think it's not best solution now, especially for traceapi( it can not hook GetThreadLocale ). 

consider detour src build configuration is [`D_WIN32_WINNT=0x501`](https://github.com/microsoft/Detours/blob/master/src/Makefile#L24) now, so update the samples's build macro to high value, 0x0501(same as source code define macro)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/Detours/pull/247)