### PR TITLE
Fix: CI-Build not working due to wrong branch in config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,12 @@ env:
   # Compile in parallel where possible.
   CL: /MP
 
-# Triggers the workflow on push or pull request events for the master branch.
+# Triggers the workflow on push or pull request events for the main branch.
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
Sometime ago the master branch got renamed to main but we didnt update the ci-build

I already ran some builds on my fork https://github.com/1fxe/Detours/actions/workflows/main.yml