### PR TITLE
Work-around an issue in Arm64 regarding the isolated use of CONTEXT_CONTROL.

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1837,35 +1837,40 @@ LONG WINAPI DetourTransactionCommitEx(_Out_opt_ PVOID **pppFailedPointer)
         }
     }
 
-    // Update any suspended threads.
-    for (t = s_pPendingThreads; t != NULL; t = t->pNext) {
-        CONTEXT cxt;
-        cxt.ContextFlags = CONTEXT_CONTROL;
-
 #undef DETOURS_EIP
+#undef DETOURS_CONTEXT_FLAGS
 
 #ifdef DETOURS_X86
 #define DETOURS_EIP         Eip
+#define DETOURS_CONTEXT_FLAGS CONTEXT_CONTROL
 #endif // DETOURS_X86
 
 #ifdef DETOURS_X64
 #define DETOURS_EIP         Rip
+#define DETOURS_CONTEXT_FLAGS (CONTEXT_CONTROL | CONTEXT_INTEGER)
 #endif // DETOURS_X64
 
 #ifdef DETOURS_IA64
 #define DETOURS_EIP         StIIP
+#define DETOURS_CONTEXT_FLAGS CONTEXT_CONTROL
 #endif // DETOURS_IA64
 
 #ifdef DETOURS_ARM
 #define DETOURS_EIP         Pc
+#define DETOURS_CONTEXT_FLAGS CONTEXT_CONTROL
 #endif // DETOURS_ARM
 
 #ifdef DETOURS_ARM64
 #define DETOURS_EIP         Pc
+#define DETOURS_CONTEXT_FLAGS (CONTEXT_CONTROL | CONTEXT_INTEGER)
 #endif // DETOURS_ARM64
 
 typedef ULONG_PTR DETOURS_EIP_TYPE;
 
+    // Update any suspended threads.
+    for (t = s_pPendingThreads; t != NULL; t = t->pNext) {
+        CONTEXT cxt;
+        cxt.ContextFlags = DETOURS_CONTEXT_FLAGS;
         if (GetThreadContext(t->hThread, &cxt)) {
             for (o = s_pPendingOperations; o != NULL; o = o->pNext) {
                 if (o->fIsRemove) {


### PR DESCRIPTION
Work-around an issue in Arm64 (and Arm64EC) in which LR and FP registers may become zeroed when CONTEXT_CONTROL is used without CONTEXT_INTEGER.

The addition of the CONTEXT_INTEGER flag does not translate to any real overhead: The kernel performs relatively expensive stack unwind operations for Get and Set ThreadContext touching and scanning over large unwind info datastructures. In scenario the extra few integers register copies (which share cache lines with CONTEXT_CONTROL) can't be observed in the scale and the noise.

This change is adding CONTEXT_INTEGER to the Get and SetThread context calls for both Arm64 and x86_64 so that Arm64EC is also addressed.

This issue is being addressed in the OS as well, but it will take time to disseminate the fix and backport it to all released versions. When the fix is out, this change can arguably be considered redundant, but given there is no real downside, I don't see an objective reason to not add it or making diligent plans to remove it.
