### PR TITLE
Fix detours ability to identify OS applied patches.

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -156,6 +156,8 @@ inline PBYTE detour_gen_brk(PBYTE pbCode, PBYTE pbLimit)
 
 inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
 {
+    PBYTE pbCodeOriginal;
+
     if (pbCode == NULL) {
         return NULL;
     }
@@ -179,6 +181,7 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
         PBYTE pbNew = pbCode + 2 + *(CHAR *)&pbCode[1];
         DETOUR_TRACE(("%p->%p: skipped over short jump.\n", pbCode, pbNew));
         pbCode = pbNew;
+        pbCodeOriginal = pbCode;
 
         // First, skip over the import vector if there is one.
         if (pbCode[0] == 0xff && pbCode[1] == 0x25) {   // jmp [imm32]
@@ -195,6 +198,23 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
             pbNew = pbCode + 5 + *(UNALIGNED INT32 *)&pbCode[1];
             DETOUR_TRACE(("%p->%p: skipped over long jump.\n", pbCode, pbNew));
             pbCode = pbNew;
+
+            // Patches applied by the OS will jump through an HPAT page to get
+            // the target function in the patch image. The jump is always performed
+            // to the target function found at the current instruction pointer + 
+            // PAGE_SIZE - 6 (size of jump).
+            // If this is an OS patch, we want to detour at the point of the target function
+            // padding in the base image. Ideally, we would detour at the target function, but
+            // since it's patched it begins with a short jump (to padding) which isn't long 
+            // enough to hold the detour code bytes.   
+            if (pbCode[0] == 0xff && 
+                pbCode[1] == 0x25 && 
+                *(UNALIGNED INT32 *)&pbCode[2] == (UNALIGNED INT32)(pbCode + 0x1000)) {   // jmp [rip+PAGE_SIZE-6]
+
+                DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function. \n", pbCode, pbCodeOriginal));
+                pbCode = pbCodeOriginal;
+            }
+
         }
     }
     return pbCode;
@@ -369,6 +389,8 @@ inline PBYTE detour_gen_brk(PBYTE pbCode, PBYTE pbLimit)
 
 inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
 {
+    PBYTE pbCodeOriginal;
+
     if (pbCode == NULL) {
         return NULL;
     }
@@ -392,6 +414,7 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
         PBYTE pbNew = pbCode + 2 + *(CHAR *)&pbCode[1];
         DETOUR_TRACE(("%p->%p: skipped over short jump.\n", pbCode, pbNew));
         pbCode = pbNew;
+        pbCodeOriginal = pbCode;
 
         // First, skip over the import vector if there is one.
         if (pbCode[0] == 0xff && pbCode[1] == 0x25) {   // jmp [+imm32]
@@ -408,6 +431,21 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
             pbNew = pbCode + 5 + *(UNALIGNED INT32 *)&pbCode[1];
             DETOUR_TRACE(("%p->%p: skipped over long jump.\n", pbCode, pbNew));
             pbCode = pbNew;
+
+            // Patches applied by the OS will jump through an HPAT page to get
+            // the target function in the patch image. The jump is always performed
+            // to the target function found at the current instruction pointer + 
+            // PAGE_SIZE - 6 (size of jump).
+            // If this is an OS patch, we want to detour at the point of the target function
+            // in the base image. Since we need 5 bytes to perform the jump, detour at the 
+            // point of the long jump instead of the short jump at the start of the target. 
+            if (pbCode[0] == 0xff && 
+                pbCode[1] == 0x25 && 
+                *(UNALIGNED INT32 *)&pbCode[2] == 0xFFA) {   // jmp [rip+PAGE_SIZE-6]
+
+                DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function. \n", pbCode, pbCodeOriginal));
+                pbCode = pbCodeOriginal;
+            }
         }
     }
     return pbCode;
@@ -1151,9 +1189,45 @@ inline void detour_find_jmp_bounds(PBYTE pbCode,
     *ppUpper = (PDETOUR_TRAMPOLINE)hi;
 }
 
+inline BOOL detour_is_code_os_patched(PBYTE pbCode)
+{
+    // Identify whether the provided code pointer is a OS patch jump.
+    // We can do this by checking if a branch (b <imm26>) is present, and if so,
+    // it must be jumping to an HPAT page containing ldr <reg> [PC+PAGE_SIZE-4], br <reg>.   
+    ULONG Opcode = fetch_opcode(pbCode); 
+
+    if ((Opcode & 0xfc000000) != 0x14000000) {   
+        return FALSE;
+    }
+    // The branch must be jumping forward if it's going into the HPAT.
+    // Check that the sign bit is cleared. 
+    if ((Opcode & (1 << 25)) != 0) {   
+        return FALSE;
+    }
+    LONG Delta = (LONG)((Opcode % (1 << 26)) * 4);
+    PBYTE BranchTarget = pbCode + Delta;
+
+    // Now inspect the opcodes of the code we jumped to in order to determine if it's HPAT. 
+    ULONG HpatOpcode1 = fetch_opcode(BranchTarget);
+    ULONG HpatOpcode2 = fetch_opcode(BranchTarget + 4);
+
+    if (HpatOpcode1 != 0x58008010) {    // ldr <reg> [PC+PAGE_SIZE]
+        return FALSE;
+    }
+    if (HpatOpcode2 != 0xd61f0200) {    // br <reg>
+        return FALSE;
+    }
+    return TRUE;
+}
+
 inline BOOL detour_does_code_end_function(PBYTE pbCode)
 {
     ULONG Opcode = fetch_opcode(pbCode);
+    // When the OS has patched a function entry point, it will incorrectly
+    // appear as though the function is just a single branch instruction.
+    if (detour_is_code_os_patched(pbCode)) {
+        return FALSE;
+    }
     if ((Opcode & 0xfffffc1f) == 0xd65f0000 ||      // br <reg>
         (Opcode & 0xfc000000) == 0x14000000) {      // b <imm26>
         return TRUE;

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -201,14 +201,14 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
 
             // Patches applied by the OS will jump through an HPAT page to get
             // the target function in the patch image. The jump is always performed
-            // to the target function found at the current instruction pointer + 
+            // to the target function found at the current instruction pointer +
             // PAGE_SIZE - 6 (size of jump).
             // If this is an OS patch, we want to detour at the point of the target function
             // padding in the base image. Ideally, we would detour at the target function, but
-            // since it's patched it begins with a short jump (to padding) which isn't long 
-            // enough to hold the detour code bytes.   
-            if (pbCode[0] == 0xff && 
-                pbCode[1] == 0x25 && 
+            // since it's patched it begins with a short jump (to padding) which isn't long
+            // enough to hold the detour code bytes.
+            if (pbCode[0] == 0xff &&
+                pbCode[1] == 0x25 &&
                 *(UNALIGNED INT32 *)&pbCode[2] == (UNALIGNED INT32)(pbCode + 0x1000)) {   // jmp [rip+PAGE_SIZE-6]
 
                 DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function. \n", pbCode, pbCodeOriginal));
@@ -434,13 +434,13 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
 
             // Patches applied by the OS will jump through an HPAT page to get
             // the target function in the patch image. The jump is always performed
-            // to the target function found at the current instruction pointer + 
+            // to the target function found at the current instruction pointer +
             // PAGE_SIZE - 6 (size of jump).
             // If this is an OS patch, we want to detour at the point of the target function
-            // in the base image. Since we need 5 bytes to perform the jump, detour at the 
-            // point of the long jump instead of the short jump at the start of the target. 
-            if (pbCode[0] == 0xff && 
-                pbCode[1] == 0x25 && 
+            // in the base image. Since we need 5 bytes to perform the jump, detour at the
+            // point of the long jump instead of the short jump at the start of the target.
+            if (pbCode[0] == 0xff &&
+                pbCode[1] == 0x25 &&
                 *(UNALIGNED INT32 *)&pbCode[2] == 0xFFA) {   // jmp [rip+PAGE_SIZE-6]
 
                 DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function. \n", pbCode, pbCodeOriginal));
@@ -1193,21 +1193,21 @@ inline BOOL detour_is_code_os_patched(PBYTE pbCode)
 {
     // Identify whether the provided code pointer is a OS patch jump.
     // We can do this by checking if a branch (b <imm26>) is present, and if so,
-    // it must be jumping to an HPAT page containing ldr <reg> [PC+PAGE_SIZE-4], br <reg>.   
-    ULONG Opcode = fetch_opcode(pbCode); 
+    // it must be jumping to an HPAT page containing ldr <reg> [PC+PAGE_SIZE-4], br <reg>.
+    ULONG Opcode = fetch_opcode(pbCode);
 
-    if ((Opcode & 0xfc000000) != 0x14000000) {   
+    if ((Opcode & 0xfc000000) != 0x14000000) {
         return FALSE;
     }
     // The branch must be jumping forward if it's going into the HPAT.
-    // Check that the sign bit is cleared. 
-    if ((Opcode & (1 << 25)) != 0) {   
+    // Check that the sign bit is cleared.
+    if ((Opcode & 0x2000000) != 0) {
         return FALSE;
     }
-    LONG Delta = (LONG)((Opcode % (1 << 26)) * 4);
+    ULONG Delta = (ULONG)((Opcode & 0x1FFFFFF) * 4);
     PBYTE BranchTarget = pbCode + Delta;
 
-    // Now inspect the opcodes of the code we jumped to in order to determine if it's HPAT. 
+    // Now inspect the opcodes of the code we jumped to in order to determine if it's HPAT.
     ULONG HpatOpcode1 = fetch_opcode(BranchTarget);
     ULONG HpatOpcode2 = fetch_opcode(BranchTarget + 4);
 

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -306,6 +306,8 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
         goto finish;
     }
 
+    inh.OptionalHeader.CheckSum = 0;
+
     if (!WriteProcessMemory(hProcess, pbModule, &idh, sizeof(idh), NULL)) {
         DETOUR_TRACE(("WriteProcessMemory(idh) failed: %lu\n", GetLastError()));
         goto finish;

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -306,8 +306,6 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
         goto finish;
     }
 
-    inh.OptionalHeader.CheckSum = 0;
-
     if (!WriteProcessMemory(hProcess, pbModule, &idh, sizeof(idh), NULL)) {
         DETOUR_TRACE(("WriteProcessMemory(idh) failed: %lu\n", GetLastError()));
         goto finish;


### PR DESCRIPTION
This change allows for interoperability between OS applied patches and detours (x64/arm64/x86). When a detour is active and an OS patch is attempted to be applied, the attempt will fail since it's not safe/secure to patch code amidst unexpected code stream. However, it is safe for the detours library to insert a detour into a function that has already been patched by the OS. In the event a binary/process is already detoured and a patch needs to be applied, the process can simply be restarted to get the patch applied prior to the detour initialization. 

Amd64:
Prior to this change, when a patched binary has a detour applied to it, the detour application will incorrectly redirect to the detour at the point of the HPAT code page jump. This results in failure to insert the detour code, since the detours library cannot modify the HPAT region. Now, the detours library first verifies that it has encountered an OS applied patch function, and if so, it redirects execution to the detour at the point of the 6-byte function padding leading up to the patched function. 

Arm64:
Similar to the amd64 issue, the detour code was interpreting the patch function jump as an end-of-function instruction, resulting in failure to apply the detour. The detour library now verifies that the code encountered is an OS patch and modifies the bytes at the start of the patched function.  

x86:
Same as amd64, with a slight deviation in expected code stream for OS applied patches. 

One other minor change was needed in uimports.cpp where the NT header checksum field was being zeroed, leading to patch applicability failing (since the OS uses file checksum/timestamp fields to identify a patch).

