### PR TITLE
Trivial fixes for commit 309926ad

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -209,9 +209,9 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
             // enough to hold the detour code bytes.
             if (pbCode[0] == 0xff &&
                 pbCode[1] == 0x25 &&
-                *(UNALIGNED INT32 *)&pbCode[2] == (UNALIGNED INT32)(pbCode + 0x1000)) {   // jmp [rip+PAGE_SIZE-6]
+                *(UNALIGNED INT32 *)&pbCode[2] == (UNALIGNED INT32)(pbCode + 0x1000)) {   // jmp [eip+PAGE_SIZE-6]
 
-                DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function. \n", pbCode, pbCodeOriginal));
+                DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function.\n", pbCode, pbCodeOriginal));
                 pbCode = pbCodeOriginal;
             }
 
@@ -443,7 +443,7 @@ inline PBYTE detour_skip_jmp(PBYTE pbCode, PVOID *ppGlobals)
                 pbCode[1] == 0x25 &&
                 *(UNALIGNED INT32 *)&pbCode[2] == 0xFFA) {   // jmp [rip+PAGE_SIZE-6]
 
-                DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function. \n", pbCode, pbCodeOriginal));
+                DETOUR_TRACE(("%p->%p: OS patch encountered, reset back to long jump 5 bytes prior to target function.\n", pbCode, pbCodeOriginal));
                 pbCode = pbCodeOriginal;
             }
         }


### PR DESCRIPTION
Trivial fixes for comment and debug output
- Correct `rip` to `eip` on x86
- Remove space between `.` and `\n` as other debug outputs