### PR TITLE
Fix: Correct sizeof usage in `DetourTransactionCommitEx`

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1945,7 +1945,7 @@ typedef ULONG_PTR DETOURS_EIP_TYPE;
                 if (o->fIsRemove) {
                     if (cxt.DETOURS_EIP >= (DETOURS_EIP_TYPE)(ULONG_PTR)o->pTrampoline &&
                         cxt.DETOURS_EIP < (DETOURS_EIP_TYPE)((ULONG_PTR)o->pTrampoline
-                                                             + sizeof(o->pTrampoline))
+                                                             + sizeof(*o->pTrampoline))
                        ) {
 
                         cxt.DETOURS_EIP = (DETOURS_EIP_TYPE)


### PR DESCRIPTION
This pull request fixes a bug in `DetourTransactionCommitEx` where `sizeof(o->pTrampoline)` was incorrectly used instead of `sizeof(*o->pTrampoline)`. This caused the size of the pointer to be used rather than the size of the trampoline structure, potentially leading to incorrect adjustments of thread instruction pointers.