### PR TITLE
Fix C_ASSERT linkage conflicts when building with MinGW-w64

### DIFF
--- a/src/detours.h
+++ b/src/detours.h
@@ -467,6 +467,10 @@ typedef struct _DETOUR_EXE_RESTORE
 
 } DETOUR_EXE_RESTORE, *PDETOUR_EXE_RESTORE;
 
+#endif // _WIN32
+#ifdef __cplusplus
+}
+#endif
 #ifdef IMAGE_NT_OPTIONAL_HDR64_MAGIC
 C_ASSERT(sizeof(IMAGE_NT_HEADERS64) == 0x108);
 #endif
@@ -475,8 +479,14 @@ C_ASSERT(sizeof(IMAGE_NT_HEADERS64) == 0x108);
 #ifdef _WIN64
 C_ASSERT(sizeof(DETOUR_EXE_RESTORE) == 0x688);
 #else
+#ifdef _WIN32
 C_ASSERT(sizeof(DETOUR_EXE_RESTORE) == 0x678);
-#endif
+#endif // _WIN32
+#endif // _WIN64
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
 
 typedef struct _DETOUR_EXE_HELPER
 {


### PR DESCRIPTION
This PR fixes a compilation error that occurs when building Detours with MinGW-w64 toolchain. The issue arises from conflicting C_ASSERT declarations between ws2tcpip.h (C++ linkage) and detours.h (C linkage).

The fix moves C_ASSERT declarations out of the extern "C" block to preserve C++ linkage consistently. This allows Detours to compile successfully with MinGW-w64 while maintaining the same behavior.

Specifically:
- Moved size verification C_ASSERTs outside of extern "C" block
- Maintains functionality while resolving the linkage conflict
- Allows successful compilation with MinGW-w64 toolchain

This is important for projects using MinGW-w64 to build applications that depend on Detours, particularly when working with network-related functionality that requires ws2tcpip.h.

Before this change, attempting to build with MinGW-w64 would fail with:
```conflicting declaration of 'void __C_ASSERT__(int*)' with 'C' linkage```

The fix allows seamless integration while keeping the original verification logic intact.