### PR TITLE
CI: Disable 32-bit ARM in the CI builds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Initialize CodeQL for C++
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         if: ${{ matrix.os == 'windows-2019' && matrix.conf == 'Debug' }}
         with:
           languages: cpp
@@ -56,14 +56,14 @@ jobs:
         if: ${{ matrix.arch == 'x86' || matrix.arch == 'x64' }}
 
       - name: Upload artifacts for ${{ matrix.arch }} on ${{ matrix.os }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.os }}
+          name: artifacts-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.conf }}
           path: |
             lib.*/
             bin.*/
             include/
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         if: ${{ matrix.os == 'windows-2019' && matrix.conf == 'Debug' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
-        arch: [x86, x64, x64_arm, x64_arm64]
+        arch: [x86, x64, x64_arm64]
         conf: [Release, Debug]
 
     steps:


### PR DESCRIPTION
The 32-bit ARM builds no longer succeed with the latest platform SDK because 32-bit ARM support has been deprecated and there are no longer libs for things like ws_32.  This is why the windows-2022 CI builds are failing for the two 32-bit ARM jobs.  32-bit ARM isn't much of a concern for anybody, I'm just going ahead and disabling it for the CI runs for now.