### PR TITLE
Fix detour_does_code_end_function for ARM64

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1228,7 +1228,7 @@ inline BOOL detour_does_code_end_function(PBYTE pbCode)
     if (detour_is_code_os_patched(pbCode)) {
         return FALSE;
     }
-    if ((Opcode & 0xfffffc1f) == 0xd65f0000 ||      // br <reg>
+    if ((Opcode & 0xffbffc1f) == 0xd61f0000 ||      // ret/br <reg>
         (Opcode & 0xfc000000) == 0x14000000) {      // b <imm26>
         return TRUE;
     }


### PR DESCRIPTION
It incorrectly returned FALSE for `br <reg>` instructions.

The bug caused Detours to override follow-up instructions after a function end, instead of failing, for example:
```
00007ffc`29e4b910 c9e6dab0 adrp    x9, 00007FFBDFB24000
00007ffc`29e4b914 20011fd6 br      x9
00007ffc`29e4b918 ; Unrelated instruction or data
```

The previous check (`(Opcode & 0xfffffc1f) == 0xd65f0000`) only matched `ret <reg>` instructions, despite the incorrect comment.

ARM64 instruction references:
* [`RET {<Xn>}`](https://developer.arm.com/documentation/ddi0602/2025-03/Base-Instructions/RET--Return-from-subroutine-)
* [`BR <Xn>`](https://developer.arm.com/documentation/ddi0602/2025-03/Base-Instructions/BR--Branch-to-register-)