### PR TITLE
Fix x86 inject to x64 process failure on WoA

### DIFF
--- a/src/detours.h
+++ b/src/detours.h
@@ -834,6 +834,24 @@ BOOL WINAPI DetourProcessViaHelperDllsW(_In_ DWORD dwTargetPid,
 #define DetourProcessViaHelperDlls      DetourProcessViaHelperDllsA
 #endif // !UNICODE
 
+BOOL WINAPI DetourProcessViaHelperDllsExA(_In_ DWORD dwTargetPid,
+                                          _In_ LPCSTR runDll,
+                                          _In_ DWORD nDlls,
+                                          _In_reads_(nDlls) LPCSTR *rlpDlls,
+                                          _In_ PDETOUR_CREATE_PROCESS_ROUTINEA pfCreateProcessA);
+
+BOOL WINAPI DetourProcessViaHelperDllsExW(_In_ DWORD dwTargetPid,
+                                          _In_ LPCSTR runDll,
+                                          _In_ DWORD nDlls,
+                                          _In_reads_(nDlls) LPCSTR *rlpDlls,
+                                          _In_ PDETOUR_CREATE_PROCESS_ROUTINEW pfCreateProcessW);
+
+#ifdef UNICODE
+#define DetourProcessViaHelperDllsEx    DetourProcessViaHelperDllsExW
+#else
+#define DetourProcessViaHelperDllsEx    DetourProcessViaHelperDllsExA
+#endif // !UNICODE
+
 BOOL WINAPI DetourUpdateProcessWithDll(_In_ HANDLE hProcess,
                                        _In_reads_(nDlls) LPCSTR *rlpDlls,
                                        _In_ DWORD nDlls);


### PR DESCRIPTION
Add a new interface DetourProcessViaHelperDllsEx that has an individual parameter that accepts a dll path to be loaded by rundll32.exe. But the payload data is still copied from rlpDlls.

Addresses #358

With this change, the x86 process is able to start the helper process (rundll32.exe) with an a64 dll loaded, but inject a x64 dll to the target process.