### PR TITLE
Fix unexpected `lpProcessInformation` output when `CreateProcess` failed

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -928,12 +928,15 @@ BOOL WINAPI DetourCreateProcessWithDllA(_In_opt_ LPCSTR lpApplicationName,
                                lpStartupInfo,
                                &pi);
 
-    if (lpProcessInformation != NULL) {
-        CopyMemory(lpProcessInformation, &pi, sizeof(pi));
+    if (!fResult) {
+        if (lpProcessInformation != NULL) {
+            ZeroMemory(lpProcessInformation, sizeof(*lpProcessInformation));
+        }
+        return FALSE;
     }
 
-    if (!fResult) {
-        return FALSE;
+    if (lpProcessInformation != NULL) {
+        CopyMemory(lpProcessInformation, &pi, sizeof(pi));
     }
 
     LPCSTR rlpDlls[2];
@@ -985,12 +988,15 @@ BOOL WINAPI DetourCreateProcessWithDllW(_In_opt_ LPCWSTR lpApplicationName,
                                     lpStartupInfo,
                                     &pi);
 
-    if (lpProcessInformation) {
-        CopyMemory(lpProcessInformation, &pi, sizeof(pi));
+    if (!fResult) {
+        if (lpProcessInformation != NULL) {
+            ZeroMemory(lpProcessInformation, sizeof(*lpProcessInformation));
+        }
+        return FALSE;
     }
 
-    if (!fResult) {
-        return FALSE;
+    if (lpProcessInformation != NULL) {
+        CopyMemory(lpProcessInformation, &pi, sizeof(pi));
     }
 
     LPCSTR rlpDlls[2];


### PR DESCRIPTION
If `CreateProcess` failed, `lpProcessInformation` should be zeroed (Windows behavior), but the current code is returning uninitialized values (the local variable `pi`).

A simple way to fix this is `PROCESS_INFORMATION pi = { 0 };`, but this will result in an unnecessary `ZeroMemory` call in success path or an unnecessary `CopyMemory` call in fail path, so I chose another way to fix it.