### PR TITLE
Remove windows-2019 from build matrix.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
+        os: [windows-2022]
         arch: [x86, x64, x64_arm64]
         conf: [Release, Debug]
 


### PR DESCRIPTION
The windows-2019 images have been deprecated and no longer work.