### PR TITLE
Fix `XBEGIN` C7 F8 decoding

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -755,9 +755,9 @@ PBYTE CDetourDis::CopyC7(REFCOPYENTRY pEntry, PBYTE pbDst, PBYTE pbSrc)
 {
     (void)pEntry;
 
-    // C7 /7 is XBEGIN rel32 (or rel16 with 66 prefix).
+    // C7 F8 is XBEGIN rel32 (or rel16 with 66 prefix).
     // It has a relative displacement that must be relocated like CALL/JMP.
-    if (0x38 == (0x38 & pbSrc[1])) {    // reg(bits 543) of ModR/M == 111
+    if (pbSrc[1] == 0xF8) {
         static const COPYENTRY ce = /* c7 /7 */ { 6, 4, 0, 2, 0, &CDetourDis::CopyBytes };
         return (this->*ce.pfCopy)(&ce, pbDst, pbSrc);
     }


### PR DESCRIPTION
Addendum to #374, already fixed in my [SlimDetours](https://github.com/KNSoft/KNSoft.SlimDetours) in [commit 65b60a7](https://github.com/KNSoft/KNSoft.SlimDetours/commit/65b60a746ee4f16e4d76dc6b66475b025f9b278b).

Only the exact C7 F8 encoding is `XBEGIN`. The previous C7 /7 check also treated other ModR/M forms as `XBEGIN` and copied them as rel16/32 targets instead of invalid or legacy C7 forms.

See also the latest [Intel® 64 and IA-32 Architectures Software Developer's Manual Combined Volumes 2A, 2B, 2C, and 2D: Instruction Set Reference, A- Z](https://cdrdv2.intel.com/v1/dl/getContent/671110):
<img width="1059" height="417" alt="image" src="https://github.com/user-attachments/assets/4eceec6b-16c7-42b1-8d7f-cf88facf9a1e" />