### PR TITLE
Fix `REX2 JMPABS` target detection

### DIFF
--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -975,9 +975,9 @@ PBYTE CDetourDis::CopyRex2(REFCOPYENTRY pEntry, PBYTE pbDst, PBYTE pbSrc)
         pbOut = (this->*pEntry2->pfCopy)(pEntry2, pbDst + 2, pbSrc + 2);
     }
 
-    // JMPABS: REX2 with payload=0x00 (M=0, W=0, all ext bits 0) and opcode A1.
+    // JMPABS: REX2 with M=0, W=0, and opcode A1. Other payload bits are ignored.
     // This is an absolute 64-bit jump whose target is the 8-byte immediate.
-    if (payload == 0x00 && pbSrc[2] == 0xA1) {
+    if ((payload & 0x88) == 0x00 && pbSrc[2] == 0xA1) {
         *m_ppbTarget = *(UNALIGNED PBYTE*)&pbSrc[3];
     }
 


### PR DESCRIPTION
Addendum to #374. Already fixed in my [SlimDetours](https://github.com/KNSoft/KNSoft.SlimDetours) in [commit 056d625](https://github.com/KNSoft/KNSoft.SlimDetours/commit/056d625a8bd6f96dbc9731edc0fe163f095d0058).

`JMPABS` only requires REX2.M=0, REX2.W=0, and opcode A1. Ignore the remaining `REX2` payload bits when recognizing the absolute target, matching Intel APX semantics.

See also the latest [Intel® Advanced Performance Extensions (Intel® APX) Architecture Specification](https://cdrdv2.intel.com/v1/dl/getContent/784266):
<img width="969" height="243" alt="image" src="https://github.com/user-attachments/assets/5478c130-9a3d-49f9-a452-c75cf9f62337" />
<img width="1002" height="276" alt="image" src="https://github.com/user-attachments/assets/7ced57ce-48e4-4827-998c-83b4382dd732" />

