### PR TITLE
Fix ARM64 sign extension helper

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1080,7 +1080,7 @@ inline INT64 detour_sign_extend(UINT64 value, UINT bits)
     const UINT left = 64 - bits;
     const INT64 m1 = -1;
     const INT64 wide = (INT64)(value << left);
-    const INT64 sign = (wide < 0) ? (m1 << left) : 0;
+    const INT64 sign = (wide < 0) ? (m1 << bits) : 0;
     return value | sign;
 }
 


### PR DESCRIPTION
Fixes #296. I fixed this in my [SlimDetours commit fc42391](https://github.com/KNSoft/KNSoft.SlimDetours/commit/fc423914895bdaa14c3c3e628c95d50a85555974), and now create this PR to Detours.

`detour_sign_extend` should build the sign-extension mask from the source bit width, not from the amount used to shift the sign bit into position.

Using 64 - bits places the mask at the wrong bit position and produces incorrect results for signed values whose sign bit is set. One affected path is ARM64 import thunk decoding, where negative `ADRP` page offsets can be decoded incorrectly.

Using the example from #296, with `value = 0x0ffea2e4` and `bits = 28`, the sign bit is set, so the value should be sign-extended.

The current code uses `m1 << left`, where `left = 64 - bits = 36`:
```
0xfffffff000000000 | 0x000000000ffea2e4 = 0xfffffff00ffea2e4
```

This is incorrect because the mask starts at bit 36. It should start at the source width, bit 28:
```
0xfffffffff0000000 | 0x000000000ffea2e4 = 0xfffffffffffea2e4
```
Therefore the sign mask should use `m1 << bits`.