### PR TITLE
Follow ARM64 B <label> branches to import thunks

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -1170,6 +1170,26 @@ then unsigned size-unscaled (8) 12-bit offset, then opcode bits 0xF94.
             }
         }
     }
+
+    // Skip over a branch to the import jump if there is one.
+    if ((Opcode & 0xfc000000) == 0x14000000) {
+        // B <imm26>
+        INT64 branchOffset = (Opcode & 0x03ffffff) << 2;
+        if ((Opcode & 0x02000000) != 0) {
+            branchOffset |= (INT64)0xfffffffff0000000ULL;
+        }
+        PBYTE const pbBranchTarget = pbCode + branchOffset;
+        ULONG const BranchOpcode = fetch_opcode(pbBranchTarget);
+
+        if ((BranchOpcode & 0x9f00001f) == 0x90000010) {
+            PBYTE const pbNew = detour_skip_jmp(pbBranchTarget, ppGlobals);
+
+            if (pbNew != pbBranchTarget) {
+                DETOUR_TRACE(("%p->%p: skipped over branch to import table.\n", pbCode, pbNew));
+                return pbNew;
+            }
+        }
+    }
     return pbCode;
 }
 


### PR DESCRIPTION
Fixes #295. Already fixed in my [SlimDetours](https://github.com/KNSoft/KNSoft.SlimDetours) in [commit 3560905](https://github.com/KNSoft/KNSoft.SlimDetours/commit/3560905a172467c3eada812d476df838052994c9).

Handle ARM64 entrypoints that start with B <label> when the branch target is an import thunk recognized by the normal ADRP/LDR/BR path.

As #295 said, If the #295 fix is merged by itself, the initial B <label> branch will be decoded correctly and Detours can reach the label. However, if the following ADRP uses a negative page delta, it can still be affected by the existing sign-extension bug tracked in #296. Ideally, both fixes (this and #380) should be merged.