### PR TITLE
Fix page protection restoration on update failures

### DIFF
--- a/src/creatwth.cpp
+++ b/src/creatwth.cpp
@@ -591,15 +591,18 @@ static BOOL UpdateFrom32To64(HANDLE hProcess, HMODULE hModule, WORD machine,
     /////////////////////////////////////////////////////// Write new headers.
     //
     DWORD dwProtect = 0;
+    DWORD dwOld = 0;
+    DWORD dwLastError = 0;
     if (!DetourVirtualProtectSameExecuteEx(hProcess, pbModule, inh64.OptionalHeader.SizeOfHeaders,
                                            PAGE_EXECUTE_READWRITE, &dwProtect)) {
         return FALSE;
     }
 
     if (!WriteProcessMemory(hProcess, pnh, &inh64, sizeof(inh64), NULL)) {
+        dwLastError = GetLastError();
         DETOUR_TRACE(("WriteProcessMemory(inh@%p..%p) failed: %lu\n",
-                      pnh, pnh + sizeof(inh64), GetLastError()));
-        return FALSE;
+                      pnh, pnh + sizeof(inh64), dwLastError));
+        goto restore;
     }
     DETOUR_TRACE(("WriteProcessMemory(inh@%p..%p)\n", pnh, pnh + sizeof(inh64)));
 
@@ -608,15 +611,17 @@ static BOOL UpdateFrom32To64(HANDLE hProcess, HMODULE hModule, WORD machine,
         inh64.FileHeader.SizeOfOptionalHeader;
     cb = inh64.FileHeader.NumberOfSections * sizeof(IMAGE_SECTION_HEADER);
     if (!WriteProcessMemory(hProcess, psects, &sects, cb, NULL)) {
+        dwLastError = GetLastError();
         DETOUR_TRACE(("WriteProcessMemory(ish@%p..%p) failed: %lu\n",
-                      psects, psects + cb, GetLastError()));
-        return FALSE;
+                      psects, psects + cb, dwLastError));
+        goto restore;
     }
     DETOUR_TRACE(("WriteProcessMemory(ish@%p..%p)\n", psects, psects + cb));
 
     // Record the updated headers.
     if (!RecordExeRestore(hProcess, hModule, der)) {
-        return FALSE;
+        dwLastError = GetLastError();
+        goto restore;
     }
 
     // Remove the import table.
@@ -625,19 +630,27 @@ static BOOL UpdateFrom32To64(HANDLE hProcess, HMODULE hModule, WORD machine,
         inh64.IMPORT_DIRECTORY.Size = 0;
 
         if (!WriteProcessMemory(hProcess, pnh, &inh64, sizeof(inh64), NULL)) {
+            dwLastError = GetLastError();
             DETOUR_TRACE(("WriteProcessMemory(inh@%p..%p) failed: %lu\n",
-                          pnh, pnh + sizeof(inh64), GetLastError()));
-            return FALSE;
+                          pnh, pnh + sizeof(inh64), dwLastError));
+            goto restore;
         }
     }
 
-    DWORD dwOld = 0;
     if (!VirtualProtectEx(hProcess, pbModule, inh64.OptionalHeader.SizeOfHeaders,
                           dwProtect, &dwOld)) {
         return FALSE;
     }
 
     return TRUE;
+
+  restore:
+    if (!VirtualProtectEx(hProcess, pbModule, inh64.OptionalHeader.SizeOfHeaders,
+                          dwProtect, &dwOld)) {
+        DETOUR_TRACE(("VirtualProtectEx(inh) restore failed: %lu\n", GetLastError()));
+    }
+    SetLastError(dwLastError);
+    return FALSE;
 }
 #endif // DETOURS_64BIT
 
@@ -864,7 +877,13 @@ BOOL WINAPI DetourUpdateProcessWithDllEx(_In_ HANDLE hProcess,
         }
 
         if (!WriteProcessMemory(hProcess, der.pclr, &clr, sizeof(clr), NULL)) {
-            DETOUR_TRACE(("WriteProcessMemory(clr) failed: %lu\n", GetLastError()));
+            DWORD dwLastError = GetLastError();
+            DETOUR_TRACE(("WriteProcessMemory(clr) failed: %lu\n", dwLastError));
+            DWORD dwOld = 0;
+            if (!VirtualProtectEx(hProcess, der.pclr, sizeof(clr), dwProtect, &dwOld)) {
+                DETOUR_TRACE(("VirtualProtectEx(clr) restore failed: %lu\n", GetLastError()));
+            }
+            SetLastError(dwLastError);
             return FALSE;
         }
 

--- a/src/uimports.cpp
+++ b/src/uimports.cpp
@@ -207,6 +207,8 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
 
     DWORD obBase = (DWORD)(pbNewIid - pbModule);
     DWORD dwProtect = 0;
+    DWORD dwOld = 0;
+    DWORD dwLastError = 0;
 
     if (inh.IMPORT_DIRECTORY.VirtualAddress != 0) {
         // Read the old import directory if it exists.
@@ -309,14 +311,16 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
     inh.OptionalHeader.CheckSum = 0;
 
     if (!WriteProcessMemory(hProcess, pbModule, &idh, sizeof(idh), NULL)) {
-        DETOUR_TRACE(("WriteProcessMemory(idh) failed: %lu\n", GetLastError()));
-        goto finish;
+        dwLastError = GetLastError();
+        DETOUR_TRACE(("WriteProcessMemory(idh) failed: %lu\n", dwLastError));
+        goto restore;
     }
     DETOUR_TRACE(("WriteProcessMemory(idh:%p..%p)\n", pbModule, pbModule + sizeof(idh)));
 
     if (!WriteProcessMemory(hProcess, pbModule + idh.e_lfanew, &inh, sizeof(inh), NULL)) {
-        DETOUR_TRACE(("WriteProcessMemory(inh) failed: %lu\n", GetLastError()));
-        goto finish;
+        dwLastError = GetLastError();
+        DETOUR_TRACE(("WriteProcessMemory(inh) failed: %lu\n", dwLastError));
+        goto restore;
     }
     DETOUR_TRACE(("WriteProcessMemory(inh:%p..%p)\n",
                   pbModule + idh.e_lfanew,
@@ -329,5 +333,13 @@ static BOOL UPDATE_IMPORTS_XX(HANDLE hProcess,
     }
 
     fSucceeded = TRUE;
+    goto finish;
+
+  restore:
+    if (!VirtualProtectEx(hProcess, pbModule, inh.OptionalHeader.SizeOfHeaders,
+                          dwProtect, &dwOld)) {
+        DETOUR_TRACE(("VirtualProtectEx(idh) restore failed: %lu\n", GetLastError()));
+    }
+    SetLastError(dwLastError);
     goto finish;
 }


### PR DESCRIPTION
Fix page protection restoration when process update operations fail.

- Restore the original page protection on failure paths.
- Preserve the original failure's `GetLastError()` value while performing cleanup.