### PR TITLE
_DETOUR_ALIGN fields require more bits

### DIFF
--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -43,20 +43,11 @@ int Detour_AssertExprWithFunctionName(int reportType, const char* filename, int 
 //
 struct _DETOUR_ALIGN
 {
-#if defined(DETOURS_ARM64) || defined(_M_ARM64EC)
     BYTE    obTarget;
     BYTE    obTrampoline;
-#else
-    BYTE    obTarget        : 3;
-    BYTE    obTrampoline    : 5;
-#endif
 };
 
-#if defined(DETOURS_ARM64) || defined(_M_ARM64EC)
 C_ASSERT(sizeof(_DETOUR_ALIGN) == 2);
-#else
-C_ASSERT(sizeof(_DETOUR_ALIGN) == 1);
-#endif
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -149,7 +140,7 @@ struct _DETOUR_TRAMPOLINE
     PBYTE           pbDetour;       // first instruction of detour function.
 };
 
-C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 72);
+C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 80);
 
 enum {
     SIZE_OF_JMP = 5
@@ -394,7 +385,7 @@ struct _DETOUR_TRAMPOLINE
 #ifdef _M_ARM64EC
 C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 208);
 #else
-C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 96);
+C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 104);
 #endif
 
 enum {
@@ -701,7 +692,7 @@ struct _DETOUR_TRAMPOLINE
 };
 
 C_ASSERT(sizeof(DETOUR_IA64_BUNDLE) == 16);
-C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 256 + DETOUR_IA64_INSTRUCTIONS_PER_BUNDLE * 16);
+C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 272 + DETOUR_IA64_INSTRUCTIONS_PER_BUNDLE * 16);
 
 enum {
     SIZE_OF_JMP = sizeof(DETOUR_IA64_BUNDLE)
@@ -814,7 +805,7 @@ struct _DETOUR_TRAMPOLINE
     PBYTE           pbDetour;       // first instruction of detour function.
 };
 
-C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 104);
+C_ASSERT(sizeof(_DETOUR_TRAMPOLINE) == 112);
 
 enum {
     SIZE_OF_JMP = 8


### PR DESCRIPTION
In both x32 and x64, obTarget, like obTrampoline, might require 5 bits, and so both can't be packed in a single byte.

Example: Target function that starts with:
```
4C 8B DC              mov r11, rsp
48 81 EC 88 00 00 00  sub rsp, 88h
```

<details><summary>Reproduction code</summary>
<p>

```cpp
/*
 * Repro for the _DETOUR_ALIGN::obTarget overflow in src/detours.cpp.
 *
 * DetourAttach copies the first instructions of the target function into the
 * trampoline and records their boundaries in DETOUR_TRAMPOLINE::rAlign: one
 * {obTarget, obTrampoline} pair per copied instruction, holding the offset of
 * the boundary in the target and in the trampoline. DetourUpdateThread uses the
 * pairs to relocate the instruction pointer of a suspended thread that sits
 * inside the moved code - detour_align_from_target when attaching,
 * detour_align_from_trampoline when detaching.
 *
 * Everywhere except ARM64 and ARM64EC, _DETOUR_ALIGN packed the pair into a
 * single byte as obTarget:3 and obTrampoline:5. Three bits hold 0..7, but the
 * moved code can be as large as sizeof(rbCode) - SIZE_OF_JMP, which is 25 bytes
 * on x86/x64, so obTarget silently wraps modulo 8. obTrampoline's five bits are
 * too narrow as well on ARM, whose rbCode is 62 bytes.
 *
 * The target below starts with
 *      4C 8B DC              mov r11, rsp     3 bytes
 *      48 81 EC 88 00 00 00  sub rsp, 88h     7 bytes
 * so Detours moves 10 bytes and records the boundaries 3 and 10. The second
 * pair is stored as {10 & 7 = 2, 10}, and the thread fixup then misbehaves:
 *
 *   Detaching, a thread suspended at trampoline+10 - a real instruction
 *   boundary - is mapped by detour_align_from_trampoline(10), which finds the
 *   pair and returns the truncated obTarget 2. The thread resumes at target+2,
 *   in the middle of "48 81 EC 88 00 00 00", and executes garbage. That is what
 *   this program demonstrates.
 *
 *   Attaching, the reverse lookup detour_align_from_target(10) matches nothing
 *   and falls back to 0, silently rewinding the thread to the start of the
 *   moved code so that already executed instructions run a second time. On
 *   x86/x64 SIZE_OF_JMP is 5, which keeps every non-final boundary below 8 and
 *   leaves the final one just outside the range DetourUpdateThread checks, so
 *   this direction only bites where SIZE_OF_JMP is larger.
 *
 * Fix: give obTarget and obTrampoline a full byte each, as ARM64 already did.
 *
 * Expected output once fixed:
 *      cbCode=10 cbRestore=10
 *      trampoline+10 -> target+10: ok
 * Before the fix the second line reads "target+2: WRONG".
 */

#include <Windows.h>
#include <stdio.h>
#include "src/detours.h"

#if !defined(_M_X64) || defined(_M_ARM64EC)
#error This repro assumes a plain x64 build.
#endif

typedef ULONG_PTR (*FN)(void);

static ULONG_PTR Detour(void) { return 0; }

static DWORD WINAPI ParkedThread(LPVOID pv) { (void)pv; return 0; }

/* Second instruction boundary of the target: mov r11,rsp + sub rsp,88h. */
#define OB_BOUNDARY 10

int main(void)
{
    static const BYTE code[] = {
        0x4C, 0x8B, 0xDC,                               /* mov r11, rsp   */
        0x48, 0x81, 0xEC, 0x88, 0x00, 0x00, 0x00,       /* sub rsp, 88h   */
        0x48, 0x81, 0xC4, 0x88, 0x00, 0x00, 0x00,       /* add rsp, 88h   */
        0x48, 0xB8, 0x34, 0x12, 0, 0, 0, 0, 0, 0,       /* mov rax, 1234h */
        0xC3                                            /* ret            */
    };
    PBYTE pbTarget = VirtualAlloc(NULL, 0x1000, MEM_COMMIT | MEM_RESERVE,
                                  PAGE_EXECUTE_READWRITE);
    PBYTE pbTrampoline;
    HANDLE hThread;
    CONTEXT cxt;
    FN pfn;
    LONG err;

    memcpy(pbTarget, code, sizeof(code));
    FlushInstructionCache(GetCurrentProcess(), pbTarget, sizeof(code));
    pfn = (FN)pbTarget;

    /* A thread that never runs; it only carries an instruction pointer. */
    hThread = CreateThread(NULL, 0, ParkedThread, NULL, CREATE_SUSPENDED, NULL);
    if (hThread == NULL) {
        printf("CreateThread failed %lu\n", GetLastError());
        return 2;
    }

    DetourTransactionBegin();
    DetourUpdateThread(GetCurrentThread());
    DetourAttach((PVOID*)&pfn, Detour);
    err = DetourTransactionCommit();
    if (err != NO_ERROR) {
        printf("attach failed %ld\n", err);
        return 2;
    }
    pbTrampoline = (PBYTE)pfn;

    /* x64 layout: cbCode at byte 30, cbRestore at byte 62. */
    printf("cbCode=%u cbRestore=%u\n", pbTrampoline[30], pbTrampoline[62]);

    /* Park the thread on the second instruction of the moved code. */
    cxt.ContextFlags = CONTEXT_CONTROL;
    if (!GetThreadContext(hThread, &cxt)) {
        printf("GetThreadContext failed %lu\n", GetLastError());
        return 2;
    }
    cxt.Rip = (DWORD64)(ULONG_PTR)(pbTrampoline + OB_BOUNDARY);
    if (!SetThreadContext(hThread, &cxt)) {
        printf("SetThreadContext failed %lu\n", GetLastError());
        return 2;
    }

    DetourTransactionBegin();
    DetourUpdateThread(GetCurrentThread());
    DetourUpdateThread(hThread);
    DetourDetach((PVOID*)&pfn, Detour);
    err = DetourTransactionCommit();
    if (err != NO_ERROR) {
        printf("detach failed %ld\n", err);
        return 2;
    }

    cxt.ContextFlags = CONTEXT_CONTROL;
    if (!GetThreadContext(hThread, &cxt)) {
        printf("GetThreadContext failed %lu\n", GetLastError());
        return 2;
    }

    err = (LONG)((ULONG_PTR)cxt.Rip - (ULONG_PTR)pbTarget);
    printf("trampoline+%d -> target+%ld: %s\n", OB_BOUNDARY, err,
           err == OB_BOUNDARY ? "ok" : "WRONG, mid-instruction");

    TerminateThread(hThread, 0);
    CloseHandle(hThread);
    return err == OB_BOUNDARY ? 0 : 1;
}
```

</p>
</details> 